### PR TITLE
fix(nextjs): fix issues with server provider

### DIFF
--- a/.changeset/early-boxes-hide.md
+++ b/.changeset/early-boxes-hide.md
@@ -1,0 +1,6 @@
+---
+'@asgardeo/nextjs': patch
+'@asgardeo/react': patch
+---
+
+Fix issues in next components

--- a/packages/nextjs/src/server/AsgardeoProvider.tsx
+++ b/packages/nextjs/src/server/AsgardeoProvider.tsx
@@ -18,34 +18,27 @@
 
 'use server';
 
-import {FC, PropsWithChildren, ReactElement} from 'react';
-import {
-  BrandingPreference,
-  AllOrganizationsApiResponse,
-  AsgardeoRuntimeError,
-  Organization,
-  User,
-  UserProfile,
-  IdToken,
-} from '@asgardeo/node';
-import AsgardeoClientProvider from '../client/contexts/Asgardeo/AsgardeoProvider';
-import AsgardeoNextClient from '../AsgardeoNextClient';
-import signInAction from './actions/signInAction';
-import signOutAction from './actions/signOutAction';
-import {AsgardeoNextConfig} from '../models/config';
-import isSignedIn from './actions/isSignedIn';
-import getUserAction from './actions/getUserAction';
-import getSessionId from './actions/getSessionId';
-import getUserProfileAction from './actions/getUserProfileAction';
-import signUpAction from './actions/signUpAction';
-import handleOAuthCallbackAction from './actions/handleOAuthCallbackAction';
+import {BrandingPreference, AsgardeoRuntimeError, Organization, User, UserProfile} from '@asgardeo/node';
 import {AsgardeoProviderProps} from '@asgardeo/react';
-import getCurrentOrganizationAction from './actions/getCurrentOrganizationAction';
-import updateUserProfileAction from './actions/updateUserProfileAction';
-import getMyOrganizations from './actions/getMyOrganizations';
+import {FC, PropsWithChildren, ReactElement} from 'react';
+import createOrganization from './actions/createOrganization';
 import getAllOrganizations from './actions/getAllOrganizations';
 import getBrandingPreference from './actions/getBrandingPreference';
+import getCurrentOrganizationAction from './actions/getCurrentOrganizationAction';
+import getMyOrganizations from './actions/getMyOrganizations';
+import getSessionId from './actions/getSessionId';
+import getUserAction from './actions/getUserAction';
+import getUserProfileAction from './actions/getUserProfileAction';
+import handleOAuthCallbackAction from './actions/handleOAuthCallbackAction';
+import isSignedIn from './actions/isSignedIn';
+import signInAction from './actions/signInAction';
+import signOutAction from './actions/signOutAction';
+import signUpAction from './actions/signUpAction';
 import switchOrganization from './actions/switchOrganization';
+import updateUserProfileAction from './actions/updateUserProfileAction';
+import AsgardeoNextClient from '../AsgardeoNextClient';
+import AsgardeoClientProvider from '../client/contexts/Asgardeo/AsgardeoProvider';
+import {AsgardeoNextConfig} from '../models/config';
 
 /**
  * Props interface of {@link AsgardeoServerProvider}
@@ -150,26 +143,6 @@ const AsgardeoServerProvider: FC<PropsWithChildren<AsgardeoServerProviderProps>>
     }
   }
 
-  const handleGetAllOrganizations = async (
-    options?: any,
-    _sessionId?: string,
-  ): Promise<AllOrganizationsApiResponse> => {
-    'use server';
-    return await getAllOrganizations(options, sessionId);
-  };
-
-  const handleSwitchOrganization = async (organization: Organization, _sessionId?: string): Promise<void> => {
-    'use server';
-    await switchOrganization(organization, sessionId);
-
-    // After switching organization, we need to refresh the page to get updated session data
-    // This is because server components don't maintain state between function calls
-    const {revalidatePath} = await import('next/cache');
-
-    // Revalidate the current path to refresh the component with new data
-    revalidatePath('/');
-  };
-
   return (
     <AsgardeoClientProvider
       organizationHandle={config?.organizationHandle}
@@ -189,9 +162,10 @@ const AsgardeoServerProvider: FC<PropsWithChildren<AsgardeoServerProviderProps>>
       updateProfile={updateUserProfileAction}
       isSignedIn={_isSignedIn}
       myOrganizations={myOrganizations}
-      getAllOrganizations={handleGetAllOrganizations}
-      switchOrganization={handleSwitchOrganization}
+      getAllOrganizations={getAllOrganizations}
+      switchOrganization={switchOrganization}
       brandingPreference={brandingPreference}
+      createOrganization={createOrganization}
     >
       {children}
     </AsgardeoClientProvider>

--- a/packages/nextjs/src/server/actions/createOrganization.ts
+++ b/packages/nextjs/src/server/actions/createOrganization.ts
@@ -18,26 +18,25 @@
 
 'use server';
 
-import {CreateOrganizationPayload, Organization} from '@asgardeo/node';
+import {CreateOrganizationPayload, Organization, AsgardeoAPIError} from '@asgardeo/node';
+import getSessionId from './getSessionId';
 import AsgardeoNextClient from '../../AsgardeoNextClient';
 
 /**
  * Server action to create an organization.
  */
-const createOrganizationAction = async (payload: CreateOrganizationPayload, sessionId: string) => {
+const createOrganization = async (payload: CreateOrganizationPayload, sessionId: string): Promise<Organization> => {
   try {
-    const client = AsgardeoNextClient.getInstance();
-    const organization: Organization = await client.createOrganization(payload, sessionId);
-    return {success: true, data: {organization}, error: null};
+    const client: AsgardeoNextClient = AsgardeoNextClient.getInstance();
+    return await client.createOrganization(payload, sessionId ?? ((await getSessionId()) as string));
   } catch (error) {
-    return {
-      success: false,
-      data: {
-        user: {},
-      },
-      error: 'Failed to create organization',
-    };
+    throw new AsgardeoAPIError(
+      `Failed to create the organization: ${error instanceof Error ? error.message : String(error)}`,
+      'createOrganization-ServerActionError-001',
+      'nextjs',
+      error instanceof AsgardeoAPIError ? error.statusCode : undefined,
+    );
   }
 };
 
-export default createOrganizationAction;
+export default createOrganization;

--- a/packages/nextjs/src/server/actions/getAllOrganizations.ts
+++ b/packages/nextjs/src/server/actions/getAllOrganizations.ts
@@ -18,16 +18,20 @@
 
 'use server';
 
-import {AllOrganizationsApiResponse, AsgardeoAPIError, Organization} from '@asgardeo/node';
+import {AllOrganizationsApiResponse, AsgardeoAPIError} from '@asgardeo/node';
+import getSessionId from './getSessionId';
 import AsgardeoNextClient from '../../AsgardeoNextClient';
 
 /**
  * Server action to get organizations.
  */
-const getAllOrganizations = async (options?: any, sessionId?: string | undefined): Promise<AllOrganizationsApiResponse> => {
+const getAllOrganizations = async (
+  options?: any,
+  sessionId?: string | undefined,
+): Promise<AllOrganizationsApiResponse> => {
   try {
-    const client = AsgardeoNextClient.getInstance();
-    return client.getAllOrganizations(options, sessionId);
+    const client: AsgardeoNextClient = AsgardeoNextClient.getInstance();
+    return await client.getAllOrganizations(options, sessionId ?? ((await getSessionId()) as string));
   } catch (error) {
     throw new AsgardeoAPIError(
       `Failed to get all the organizations for the user: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/react/src/contexts/Organization/OrganizationContext.ts
+++ b/packages/react/src/contexts/Organization/OrganizationContext.ts
@@ -16,37 +16,42 @@
  * under the License.
  */
 
-import {AllOrganizationsApiResponse, Organization} from '@asgardeo/browser';
+import {AllOrganizationsApiResponse, Organization, CreateOrganizationPayload} from '@asgardeo/browser';
 import {Context, createContext} from 'react';
 
 /**
  * Props interface of {@link OrganizationContext}
  */
 export type OrganizationContextProps = {
+  /**
+   * Function to create a new organization.
+   */
+  createOrganization?: (payload: CreateOrganizationPayload, sessionId: string) => Promise<Organization>;
   currentOrganization: Organization | null;
   error: string | null;
+  getAllOrganizations: () => Promise<AllOrganizationsApiResponse>;
   isLoading: boolean;
   myOrganizations: Organization[];
-  switchOrganization: (organization: Organization) => Promise<void>;
   revalidateMyOrganizations: () => Promise<Organization[]>;
-  getAllOrganizations: () => Promise<AllOrganizationsApiResponse>;
+  switchOrganization: (organization: Organization) => Promise<void>;
 };
 
 /**
  * Context object for managing organization data and related operations.
  */
 const OrganizationContext: Context<OrganizationContextProps | null> = createContext<null | OrganizationContextProps>({
+  createOrganization: () => null,
   currentOrganization: null,
   error: null,
-  isLoading: false,
-  myOrganizations: null,
-  switchOrganization: () => Promise.resolve(),
-  revalidateMyOrganizations: () => Promise.resolve([]),
   getAllOrganizations: () =>
     Promise.resolve({
       count: 0,
       organizations: [],
     }),
+  isLoading: false,
+  myOrganizations: null,
+  revalidateMyOrganizations: () => Promise.resolve([]),
+  switchOrganization: () => Promise.resolve(),
 });
 
 OrganizationContext.displayName = 'OrganizationContext';

--- a/packages/react/src/contexts/Organization/OrganizationProvider.tsx
+++ b/packages/react/src/contexts/Organization/OrganizationProvider.tsx
@@ -16,7 +16,12 @@
  * under the License.
  */
 
-import {AsgardeoRuntimeError, Organization, AllOrganizationsApiResponse} from '@asgardeo/browser';
+import {
+  AsgardeoRuntimeError,
+  Organization,
+  AllOrganizationsApiResponse,
+  CreateOrganizationPayload,
+} from '@asgardeo/browser';
 import {FC, PropsWithChildren, ReactElement, useCallback, useMemo, useState} from 'react';
 import OrganizationContext, {OrganizationContextProps} from './OrganizationContext';
 
@@ -29,9 +34,17 @@ export interface OrganizationProviderProps {
    */
   autoFetch?: boolean;
   /**
+   * Function to create a new organization.
+   */
+  createOrganization?: (payload: CreateOrganizationPayload, sessionId: string) => Promise<Organization>;
+  /**
    * Initial current organization
    */
   currentOrganization?: Organization | null;
+  /**
+   * Initial list of organizations
+   */
+  getAllOrganizations?: () => Promise<AllOrganizationsApiResponse>;
   /**
    * List of organizations the signed-in user belongs to.
    */
@@ -44,10 +57,6 @@ export interface OrganizationProviderProps {
    * Callback function called when switching organizations
    */
   onOrganizationSwitch?: (organization: Organization) => Promise<void>;
-  /**
-   * Initial list of organizations
-   */
-  getAllOrganizations?: () => Promise<AllOrganizationsApiResponse>;
   /**
    * Refetch the my organizations list.
    * @returns
@@ -97,6 +106,7 @@ const OrganizationProvider: FC<PropsWithChildren<OrganizationProviderProps>> = (
   onOrganizationSwitch,
   revalidateMyOrganizations,
   getAllOrganizations,
+  createOrganization,
 }: PropsWithChildren<OrganizationProviderProps>): ReactElement => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -138,13 +148,14 @@ const OrganizationProvider: FC<PropsWithChildren<OrganizationProviderProps>> = (
 
   const contextValue: OrganizationContextProps = useMemo(
     () => ({
+      createOrganization,
       currentOrganization,
       error,
+      getAllOrganizations,
       isLoading,
       myOrganizations,
-      switchOrganization,
       revalidateMyOrganizations,
-      getAllOrganizations,
+      switchOrganization,
     }),
     [
       currentOrganization,
@@ -154,6 +165,7 @@ const OrganizationProvider: FC<PropsWithChildren<OrganizationProviderProps>> = (
       switchOrganization,
       revalidateMyOrganizations,
       getAllOrganizations,
+      createOrganization,
     ],
   );
 


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request introduces several updates to improve organization management in the Asgardeo SDK. Key changes include adding support for creating organizations, enhancing error handling, and refactoring the organization-related server and client components. Below is a summary of the most important changes grouped by theme.

### Organization Management Enhancements:

* **Support for creating organizations:**
  - Added a `createOrganization` function to `OrganizationContext` and `OrganizationProvider` in `packages/react/src/contexts/Organization`. This enables users to create new organizations through the context. [[1]](diffhunk://#diff-451f07c9740bf8a104ef0c7543bb91a74ebd0419012568160603c1a03b037925L19-R54) [[2]](diffhunk://#diff-6ea8410a1600ae10a26cb7b14107af991d3ab2dfd7473ed9acdeb20dfb01ccdbL19-R24) [[3]](diffhunk://#diff-6ea8410a1600ae10a26cb7b14107af991d3ab2dfd7473ed9acdeb20dfb01ccdbR36-R47)
  - Updated the `CreateOrganization` component in `packages/nextjs/src/client/components/presentation/CreateOrganization/CreateOrganization.tsx` to use the new `createOrganization` function from the organization context instead of a custom action. [[1]](diffhunk://#diff-42f3c10727c51b0d0073b9d7f521118323ce0f83eb1109d674479710289689a4L83-R81) [[2]](diffhunk://#diff-42f3c10727c51b0d0073b9d7f521118323ce0f83eb1109d674479710289689a4L107-R120)

* **Refactoring server actions:**
  - Renamed `createOrganizationAction` to `createOrganization` and improved error handling using `AsgardeoAPIError` in `packages/nextjs/src/server/actions/createOrganization.ts`.
  - Enhanced `switchOrganization` in `packages/nextjs/src/server/actions/switchOrganization.ts` to refresh the page after switching organizations for updated session data.

### Integration Updates:

* **Context and provider adjustments:**
  - Updated `AsgardeoProvider` in both client and server contexts (`packages/nextjs/src/client/contexts/Asgardeo/AsgardeoProvider.tsx` and `packages/nextjs/src/server/AsgardeoProvider.tsx`) to include the `createOrganization` function and other related properties. [[1]](diffhunk://#diff-0abb0e8335a4c28dd6a42d47ce2048fcc129577d530a5e071c2443e597fc1204R303-R307) [[2]](diffhunk://#diff-4143adb0db4b789634074491639d5ff65ca81d1258866b6175c9ecb28dc33c4fL192-R168)

### Error Handling Improvements:

* **Runtime error handling:**
  - Added `AsgardeoRuntimeError` checks in `CreateOrganization` to ensure the `createOrganization` function is available in the context.
  - Improved error reporting in server actions, such as `createOrganization` and `switchOrganization`, using `AsgardeoAPIError` for better debugging and clarity. [[1]](diffhunk://#diff-981000d9ee6db22d2d5adf57ddaea164403df60734cbec9ae8a29c1eb64a692aL21-R42) [[2]](diffhunk://#diff-e930eaff98991c1c5290bd3a14330412372b2014aafe44fee62aa9680824350eL21-R49)

### Miscellaneous Changes:

* **Changeset creation:**
  - Added a changeset file (`.changeset/early-boxes-hide.md`) to document the patch-level updates for `@asgardeo/nextjs` and `@asgardeo/react`.

These updates streamline organization management workflows, improve error handling, and enhance the maintainability of the codebase.

### Related Issues
- https://github.com/asgardeo/web-ui-sdks/issues/81

### Related PRs
- N/A

### Checklist
- [ ] e2e cypress tests locally verified.
- [ ] Manual test round performed and verified.
- [ ] UX/UI review done on the final implementation.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)
- [ ] Integration tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Ran FindSecurityBugs plugin and verified report?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?