### PR TITLE
Change `actionId` to `action` in `v2`

### DIFF
--- a/.changeset/easy-windows-stare.md
+++ b/.changeset/easy-windows-stare.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/javascript': patch
+---
+
+Change `actionId` to `action`

--- a/packages/javascript/src/models/v2/embedded-signin-flow-v2.ts
+++ b/packages/javascript/src/models/v2/embedded-signin-flow-v2.ts
@@ -321,7 +321,7 @@ export interface EmbeddedSignInFlowRequest extends Partial<EmbeddedSignInFlowIni
    * Identifier of the specific action being triggered.
    * Corresponds to action components in the UI (e.g., submit button, social login).
    */
-  actionId?: string;
+  action?: string;
 
   /**
    * User input data collected from the form components.


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request makes a minor update to the `@asgardeo/javascript` package, specifically renaming the `actionId` property to `action` in the `EmbeddedSignInFlowRequest` interface to improve clarity and consistency.

- Renamed the `actionId` property to `action` in the `EmbeddedSignInFlowRequest` interface in `embedded-signin-flow-v2.ts` for clearer naming.
- Updated documentation and changelog to reflect the property name change.

### Related Issues
- https://github.com/asgardeo/javascript/issues/212

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
