### PR TITLE
fix(nextjs): Add missing Organization export

### DIFF
--- a/packages/nextjs/src/client/index.ts
+++ b/packages/nextjs/src/client/index.ts
@@ -19,6 +19,9 @@
 export {default as useAsgardeo} from './contexts/Asgardeo/useAsgardeo';
 export * from './contexts/Asgardeo/useAsgardeo';
 
+export {default as Organization} from './components/presentation/Organization/Organization';
+export {OrganizationProps} from './components/presentation/Organization/Organization';
+
 export {default as CreateOrganization} from './components/presentation/CreateOrganization/CreateOrganization';
 export {CreateOrganizationProps} from './components/presentation/CreateOrganization/CreateOrganization';
 


### PR DESCRIPTION
### Purpose
Adds missing exports for Organization and OrganizationProps components in the NextJS package.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
