### PR TITLE
Refactor branding preference fetching logic

### DIFF
--- a/.changeset/cold-games-lead.md
+++ b/.changeset/cold-games-lead.md
@@ -1,0 +1,6 @@
+---
+'@asgardeo/javascript': minor
+'@asgardeo/react': minor
+---
+
+Set default branding preference API call to false

--- a/packages/javascript/src/api/getBrandingPreference.ts
+++ b/packages/javascript/src/api/getBrandingPreference.ts
@@ -18,6 +18,9 @@
 
 import AsgardeoAPIError from '../errors/AsgardeoAPIError';
 import {BrandingPreference} from '../models/branding-preference';
+import {Platform} from '../models/platforms';
+import identifyPlatform from '../utils/identifyPlatform';
+import logger from '../utils/logger';
 
 /**
  * Configuration for the getBrandingPreference request
@@ -154,6 +157,32 @@ const getBrandingPreference = async ({
 
     if (!response?.ok) {
       const errorText: string = await response.text();
+
+      const platform: Platform = identifyPlatform({baseUrl} as any);
+
+      let errorDescription: string;
+      try {
+        const errorBody: {description?: string; message?: string} = JSON.parse(errorText) as {
+          description?: string;
+          message?: string;
+        };
+        errorDescription = errorBody?.description || errorBody?.message || errorText;
+      } catch {
+        errorDescription = errorText;
+      }
+
+      let platformConsoleGuidance: string;
+      if (platform === Platform.Asgardeo || platform === Platform.AsgardeoV2) {
+        platformConsoleGuidance = 'configure branding preferences in the Asgardeo console';
+      } else if (platform === Platform.IdentityServer) {
+        platformConsoleGuidance = 'configure branding preferences in the WSO2 Identity Server console';
+      } else {
+        platformConsoleGuidance = 'configure branding preferences in the platform console';
+      }
+
+      logger.warn(
+        `[BrandingError] ${errorDescription} To resolve this issue, please ${platformConsoleGuidance}. If you want to suppress this warning and stop fetching branding preferences, set \`<AsgardeoProvider>\` -> \`preferences\` -> \`theme\` -> \`inheritFromBranding\` to false.`
+      );
 
       throw new AsgardeoAPIError(
         `Failed to get branding preference: ${errorText}`,

--- a/packages/javascript/src/api/getBrandingPreference.ts
+++ b/packages/javascript/src/api/getBrandingPreference.ts
@@ -172,7 +172,7 @@ const getBrandingPreference = async ({
       }
 
       let platformConsoleGuidance: string;
-      if (platform === Platform.Asgardeo || platform === Platform.AsgardeoV2) {
+      if (platform === Platform.Asgardeo) {
         platformConsoleGuidance = 'configure branding preferences in the Asgardeo console';
       } else if (platform === Platform.IdentityServer) {
         platformConsoleGuidance = 'configure branding preferences in the WSO2 Identity Server console';

--- a/packages/javascript/src/api/getBrandingPreference.ts
+++ b/packages/javascript/src/api/getBrandingPreference.ts
@@ -181,7 +181,7 @@ const getBrandingPreference = async ({
       }
 
       logger.warn(
-        `[BrandingError] ${errorDescription} To resolve this issue, please ${platformConsoleGuidance}. If you want to suppress this warning and stop fetching branding preferences, set \`<AsgardeoProvider>\` -> \`preferences\` -> \`theme\` -> \`inheritFromBranding\` to false.`
+        `[BrandingError] ${errorDescription} To resolve this issue, please ${platformConsoleGuidance}. If you want to suppress this warning and stop fetching branding preferences, set \`<AsgardeoProvider>\` -> \`preferences\` -> \`theme\` -> \`inheritFromBranding\` to false.`,
       );
 
       throw new AsgardeoAPIError(

--- a/packages/javascript/src/models/config.ts
+++ b/packages/javascript/src/models/config.ts
@@ -381,7 +381,10 @@ export interface ThemePreferences {
    */
   direction?: 'ltr' | 'rtl';
   /**
-   * Inherit from Branding from WSO2 Identity Server or Asgardeo.
+   * Inherit branding from WSO2 Identity Server or Asgardeo.
+   * When set to `true`, the SDK will fetch and apply branding preferences from the server.
+   * Defaults to `false` — branding is not fetched unless explicitly enabled.
+   * @default false
    */
   inheritFromBranding?: boolean;
   /**

--- a/packages/javascript/src/models/config.ts
+++ b/packages/javascript/src/models/config.ts
@@ -366,7 +366,10 @@ export interface ThemePreferences {
    */
   direction?: 'ltr' | 'rtl';
   /**
-   * Inherit from Branding from WSO2 Identity Server or Asgardeo.
+   * Inherit branding from WSO2 Identity Server or Asgardeo.
+   * When set to `true`, the SDK will fetch and apply branding preferences from the server.
+   * Defaults to `false` — branding is not fetched unless explicitly enabled.
+   * @default false
    */
   inheritFromBranding?: boolean;
   /**

--- a/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
+++ b/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
@@ -476,8 +476,8 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
       return;
     }
 
-    // Enable branding by default or when explicitly enabled
-    const shouldFetchBranding: boolean = preferences?.theme?.inheritFromBranding !== false;
+    // Only fetch branding when explicitly enabled via preferences.theme.inheritFromBranding
+    const shouldFetchBranding: boolean = preferences?.theme?.inheritFromBranding === true;
 
     if (shouldFetchBranding && isInitializedSync && baseUrl && !hasFetchedBranding && !isBrandingLoading) {
       fetchBranding();
@@ -675,7 +675,7 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
             brandingPreference={brandingPreference}
             isLoading={isBrandingLoading}
             error={brandingError}
-            enabled={preferences?.theme?.inheritFromBranding !== false}
+            enabled={preferences?.theme?.inheritFromBranding === true}
             refetch={refetchBranding}
           >
             <ThemeProvider

--- a/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
+++ b/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
@@ -479,8 +479,8 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
       return;
     }
 
-    // Enable branding by default or when explicitly enabled
-    const shouldFetchBranding: boolean = preferences?.theme?.inheritFromBranding !== false;
+    // Only fetch branding when explicitly enabled via preferences.theme.inheritFromBranding
+    const shouldFetchBranding: boolean = preferences?.theme?.inheritFromBranding === true;
 
     if (shouldFetchBranding && isInitializedSync && baseUrl && !hasFetchedBranding && !isBrandingLoading) {
       fetchBranding();
@@ -695,7 +695,7 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
             brandingPreference={brandingPreference}
             isLoading={isBrandingLoading}
             error={brandingError}
-            enabled={preferences?.theme?.inheritFromBranding !== false}
+            enabled={preferences?.theme?.inheritFromBranding === true}
             refetch={refetchBranding}
           >
             <ThemeProvider


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request updates the branding preferences logic in the SDK to ensure branding is only fetched and applied when explicitly enabled, rather than by default. The changes clarify the documentation and adjust the code to require `inheritFromBranding` to be set to `true` for branding to be fetched.

Branding preferences logic update:

* Updated the documentation for the `inheritFromBranding` property in the `ThemePreferences` interface to clarify that branding is only fetched when explicitly enabled, and defaults to `false`.
* Changed the branding fetch logic in `AsgardeoProvider` to only fetch branding when `preferences.theme.inheritFromBranding` is `true`, rather than when it is not `false`.
* Updated the `enabled` prop for branding in `AsgardeoProvider` to require `preferences.theme.inheritFromBranding` to be `true`.

### Related Issues
- Fixes #384

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that branding inheritance is disabled by default and requires explicit opt-in configuration.

* **Improvements**
  * Enhanced error logging and messaging when branding preference retrieval fails.

* **Chores**
  * Applied minor dependency release bumps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asgardeo/javascript/pull/406)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->