### PR TITLE
Refactor AsgardeoReactClient initialization to fix the type issue

### DIFF
--- a/.changeset/floppy-pandas-poke.md
+++ b/.changeset/floppy-pandas-poke.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/react': patch
+---
+
+Refactor AsgardeoReactClient initialization to fix the type issue

--- a/packages/nextjs/.eslintrc.cjs
+++ b/packages/nextjs/.eslintrc.cjs
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -36,6 +36,9 @@ module.exports = {
     project: [path.resolve(__dirname, 'tsconfig.eslint.json')],
   },
   plugins: ['@wso2'],
+  rules: {
+    '@typescript-eslint/return-await': 'off',
+  },
   settings: {
     'import/resolver': {
       node: {

--- a/packages/react/src/AsgardeoReactClient.ts
+++ b/packages/react/src/AsgardeoReactClient.ts
@@ -126,14 +126,13 @@ class AsgardeoReactClient<T extends AsgardeoReactConfig = AsgardeoReactConfig> e
     }
 
     return this.withLoading(async () => {
-      this.initializeConfig = {
-        ...config,
-        organizationHandle: resolvedOrganizationHandle,
-        periodicTokenRefresh: config?.tokenLifecycle?.refreshToken?.autoRefresh 
-          ?? (config as any)?.periodicTokenRefresh,
-      };
+      this.initializeConfig = {...config, organizationHandle: resolvedOrganizationHandle};
 
-      return this.asgardeo.init(this.initializeConfig as any);
+      return this.asgardeo.init({
+        ...this.initializeConfig,
+        periodicTokenRefresh:
+          config?.tokenLifecycle?.refreshToken?.autoRefresh ?? (config as any)?.periodicTokenRefresh,
+      } as any);
     });
   }
 


### PR DESCRIPTION
### Purpose

This pull request updates the initialization logic of the `AsgardeoReactClient` to improve how the `periodicTokenRefresh` configuration is handled. The main change is moving the logic for setting `periodicTokenRefresh` from the `initializeConfig` assignment to the object passed directly to the `asgardeo.init` call, ensuring the correct value is always used during initialization.

Configuration handling improvements:

* Moved the logic for determining `periodicTokenRefresh` from the `initializeConfig` property to the argument passed to `asgardeo.init`, ensuring that the most up-to-date value is used during initialization.

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
