### PR TITLE
Fix auto refresh token logic to ensure timely token renewal

### DIFF
--- a/.changeset/loud-trams-post.md
+++ b/.changeset/loud-trams-post.md
@@ -1,5 +1,0 @@
----
-'@asgardeo/react': patch
----
-
-Improve isSignedIn method

--- a/.changeset/loud-trams-post.md
+++ b/.changeset/loud-trams-post.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/react': patch
+---
+
+Improve isSignedIn method

--- a/.changeset/short-lemons-change.md
+++ b/.changeset/short-lemons-change.md
@@ -1,5 +1,6 @@
 ---
 '@asgardeo/browser': patch
+'@asgardeo/react': patch
 ---
 
 Fix auto refresh token logic error

--- a/.changeset/short-lemons-change.md
+++ b/.changeset/short-lemons-change.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/browser': patch
+---
+
+Fix auto refresh token logic error

--- a/packages/browser/src/__legacy__/client.ts
+++ b/packages/browser/src/__legacy__/client.ts
@@ -1107,6 +1107,12 @@ export class AsgardeoSPAClient {
     return this._client?.isSignedIn();
   }
 
+  public async startAutoRefreshToken(): Promise<void> {
+    await this.isInitialized();
+
+    return (this._client as MainThreadClientInterface)?.startAutoRefreshToken();
+  }
+
   /**
    * This method specifies if there is an active session in the browser or not.
    *

--- a/packages/browser/src/__legacy__/clients/main-thread-client.ts
+++ b/packages/browser/src/__legacy__/clients/main-thread-client.ts
@@ -415,6 +415,11 @@ export const MainThreadClient = async (
     return _authenticationClient.decodeJwtToken<T>(token);
   };
 
+  const startAutoRefreshToken = async (): Promise<void> => {
+    _spaHelper.clearRefreshTokenTimeout();
+    await _spaHelper.refreshAccessTokenAutomatically(_authenticationHelper);
+  };
+
   return {
     disableHttpHandler,
     enableHttpHandler,
@@ -441,6 +446,7 @@ export const MainThreadClient = async (
     signIn,
     signOut,
     signInSilently,
+    startAutoRefreshToken,
     reInitialize,
     decodeJwtToken,
   };

--- a/packages/browser/src/__legacy__/helpers/spa-helper.ts
+++ b/packages/browser/src/__legacy__/helpers/spa-helper.ts
@@ -42,13 +42,23 @@ export class SPAHelper<T extends MainThreadClientConfig | WebWorkerClientConfig>
 
     const sessionData = await this._storageManager.getSessionData();
     if (sessionData.refresh_token) {
-      // Refresh 10 seconds before the expiry time
-      const expiryTime = parseInt(sessionData.expires_in);
-      const time = expiryTime <= 10 ? expiryTime : expiryTime - 10;
+      if (sessionData.created_at == null || sessionData.expires_in == null) {
+        return;
+      }
+      
+      const TOKEN_REFRESH_BUFFER_MS = 10_000;
+      const expiryTime = Number(sessionData.expires_in) * 1000;
+      const absoluteExpiryTime: number = sessionData.created_at + expiryTime;
+      const timeUntilRefresh = absoluteExpiryTime - Date.now() - TOKEN_REFRESH_BUFFER_MS;
+
+      if (timeUntilRefresh <= 0) {
+        await authenticationHelper.refreshAccessToken();
+        return;
+      }
 
       const timer = setTimeout(async () => {
         await authenticationHelper.refreshAccessToken();
-      }, time * 1000);
+      }, timeUntilRefresh);
 
       await this._storageManager.setTemporaryDataParameter(
         TokenConstants.Storage.StorageKeys.REFRESH_TOKEN_TIMER,

--- a/packages/browser/src/__legacy__/models/client.ts
+++ b/packages/browser/src/__legacy__/models/client.ts
@@ -67,6 +67,7 @@ export interface MainThreadClientInterface {
   getAccessToken(sessionId?: string): Promise<string>;
   getStorageManager(): Promise<StorageManager<MainThreadClientConfig>>;
   isSignedIn(): Promise<boolean>;
+  startAutoRefreshToken(): Promise<void>;
   reInitialize(config: Partial<AuthClientConfig<MainThreadClientConfig>>): Promise<void>;
   signInSilently(
     additionalParams?: Record<string, string | boolean>,

--- a/packages/react/src/AsgardeoReactClient.ts
+++ b/packages/react/src/AsgardeoReactClient.ts
@@ -336,6 +336,10 @@ class AsgardeoReactClient<T extends AsgardeoReactConfig = AsgardeoReactConfig> e
     return this.asgardeo.isSignedIn();
   }
 
+  async startAutoRefreshToken(): Promise<void> {
+    return this.asgardeo.startAutoRefreshToken();
+  }
+
   override getConfiguration(): T {
     return this.asgardeo.getConfigData() as unknown as T;
   }

--- a/packages/react/src/__temp__/api.ts
+++ b/packages/react/src/__temp__/api.ts
@@ -383,6 +383,10 @@ class AuthAPI {
     return this.client.isSignedIn();
   }
 
+  public async startAutoRefreshToken(): Promise<void> {
+    return this.client.startAutoRefreshToken();
+  }
+
   /**
    * This method specifies if the session is active or not.
    *

--- a/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
+++ b/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
@@ -271,6 +271,14 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
 
       if (isAlreadySignedIn) {
         await updateSession();
+        await asgardeo.startAutoRefreshToken();
+        return;
+      }
+
+      await asgardeo.startAutoRefreshToken().catch(() => {});
+      if (await asgardeo.isSignedIn()) {
+        await updateSession();
+        await asgardeo.startAutoRefreshToken();
         return;
       }
 

--- a/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
+++ b/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2025-2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -34,6 +34,7 @@ import {
   extractUserClaimsFromIdToken,
   EmbeddedSignInFlowResponseV2,
   TokenResponse,
+  createPackageComponentLogger,
 } from '@asgardeo/browser';
 import {FC, RefObject, PropsWithChildren, ReactElement, useEffect, useMemo, useRef, useState, useCallback} from 'react';
 import AsgardeoContext from './AsgardeoContext';
@@ -47,6 +48,11 @@ import I18nProvider from '../I18n/I18nProvider';
 import OrganizationProvider from '../Organization/OrganizationProvider';
 import ThemeProvider from '../Theme/ThemeProvider';
 import UserProvider from '../User/UserProvider';
+
+const logger: ReturnType<typeof createPackageComponentLogger> = createPackageComponentLogger(
+  '@asgardeo/react',
+  'AsgardeoProvider',
+);
 
 /**
  * Props interface of {@link AsgardeoProvider}
@@ -269,16 +275,32 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
       // User is already authenticated. Skip...
       const isAlreadySignedIn: boolean = await asgardeo.isSignedIn();
 
-      if (isAlreadySignedIn) {
+      // Start auto-refresh with a soft failure.
+      const scheduleAutoRefresh = async (): Promise<void> => {
+        try {
+          await asgardeo.startAutoRefreshToken();
+        } catch (error) {
+          logger.warn('Failed to schedule automatic token refresh.', error);
+        }
+      };
+
+      // Restore session state and kick off the refresh timer.
+      const resumeSession = async (): Promise<void> => {
         await updateSession();
-        await asgardeo.startAutoRefreshToken();
-        return;
+        await scheduleAutoRefresh();
+      };
+
+      if (isAlreadySignedIn) {
+        await resumeSession();
       }
 
-      await asgardeo.startAutoRefreshToken().catch(() => {});
+      // The access token may have expired while the refresh token is still valid.
+      // Attempt a silent refresh — startAutoRefreshToken() calls refreshAccessToken()
+      // immediately when timeUntilRefresh <= 0, then re-check sign-in status.
+      await scheduleAutoRefresh();
+
       if (await asgardeo.isSignedIn()) {
-        await updateSession();
-        await asgardeo.startAutoRefreshToken();
+        await resumeSession();
         return;
       }
 


### PR DESCRIPTION
### Purpose

This pull request fixes an error in the auto refresh token logic for the `@asgardeo/browser` package. The update ensures that access tokens are refreshed at the correct time, preventing premature or missed refreshes.

**Improvements to token refresh logic:**

* Corrected the calculation for the token refresh timer in `spa-helper.ts` to use the token's absolute expiry time and a 10-second buffer, ensuring the refresh happens just before expiration. The logic now checks for the presence of `created_at` and `expires_in` before proceeding, and immediately refreshes the token if it's already expired or about to expire.

**Changelog update:**

* Added a changeset entry documenting the patch fix for the auto refresh token logic error in `@asgardeo/browser`.

### Related Issues
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/6530
- https://github.com/asgardeo/javascript/issues/346

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?