### PR TITLE
Fix the race condition in token refresh logic

### DIFF
--- a/.changeset/quick-camels-yell.md
+++ b/.changeset/quick-camels-yell.md
@@ -1,0 +1,6 @@
+---
+'@asgardeo/browser': patch
+'@asgardeo/react': patch
+---
+
+Fix the race condition in token refresh

--- a/packages/browser/src/__legacy__/helpers/spa-helper.ts
+++ b/packages/browser/src/__legacy__/helpers/spa-helper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2020-2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -24,6 +24,7 @@ import {MainThreadClientConfig, WebWorkerClientConfig} from '../models/client-co
 export class SPAHelper<T extends MainThreadClientConfig | WebWorkerClientConfig> {
   private _authenticationClient: AsgardeoAuthClient<T>;
   private _storageManager: StorageManager<T>;
+  private _isTokenRefreshLoading: boolean = false;
 
   public constructor(authClient: AsgardeoAuthClient<T>) {
     this._authenticationClient = authClient;
@@ -52,12 +53,26 @@ export class SPAHelper<T extends MainThreadClientConfig | WebWorkerClientConfig>
       const timeUntilRefresh = absoluteExpiryTime - Date.now() - TOKEN_REFRESH_BUFFER_MS;
 
       if (timeUntilRefresh <= 0) {
-        await authenticationHelper.refreshAccessToken();
+        if (this._isTokenRefreshLoading) return;
+
+        this._isTokenRefreshLoading = true;
+        try {
+          await authenticationHelper.refreshAccessToken();
+        } finally {
+          this._isTokenRefreshLoading = false;
+        }
         return;
       }
 
       const timer = setTimeout(async () => {
-        await authenticationHelper.refreshAccessToken();
+        if (this._isTokenRefreshLoading) return;
+
+        this._isTokenRefreshLoading = true;
+        try {
+          await authenticationHelper.refreshAccessToken();
+        } finally {
+          this._isTokenRefreshLoading = false;
+        }
       }, timeUntilRefresh);
 
       await this._storageManager.setTemporaryDataParameter(


### PR DESCRIPTION
### Purpose

This pull request addresses a race condition in the token refresh logic for the `@asgardeo/browser` and `@asgardeo/react` packages. The main improvement is the introduction of a locking mechanism to prevent multiple simultaneous token refresh requests, ensuring more reliable authentication flows.

**Token Refresh Race Condition Fix**

* Added a private `_isTokenRefreshLoading` flag in the `SPAHelper` class to prevent concurrent token refresh attempts.
* Updated the token refresh logic to check and set `_isTokenRefreshLoading` before starting a refresh, and to reset it after completion, ensuring only one refresh runs at a time.

**Meta and Documentation**

* Updated copyright years in `spa-helper.ts` to include 2026.
* Added a changeset describing the patch and its purpose.

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
