### PR TITLE
feat: add rendering support for PHONE_INPUT and OTP_INPUT component types

### DIFF
--- a/.changeset/warm-phones-ring.md
+++ b/.changeset/warm-phones-ring.md
@@ -1,0 +1,6 @@
+---
+'@asgardeo/javascript': patch
+'@asgardeo/react': patch
+---
+
+Add rendering support for PHONE_INPUT and OTP_INPUT component types in the embedded flow

--- a/packages/javascript/src/models/field.ts
+++ b/packages/javascript/src/models/field.ts
@@ -25,6 +25,7 @@ export enum FieldType {
   Password = 'PASSWORD',
   Radio = 'RADIO',
   Select = 'SELECT',
+  Tel = 'TEL',
   Text = 'TEXT',
   Textarea = 'TEXTAREA',
   Time = 'TIME',

--- a/packages/react/src/components/factories/FieldFactory.tsx
+++ b/packages/react/src/components/factories/FieldFactory.tsx
@@ -187,6 +187,15 @@ export const createField = (config: FieldConfig): ReactElement => {
           autoComplete="email"
         />
       );
+    case FieldType.Tel:
+      return (
+        <TextField
+          {...commonProps}
+          type="tel"
+          onChange={(e: ChangeEvent<HTMLInputElement>): void => onChange(e.target.value)}
+          autoComplete="tel"
+        />
+      );
     case FieldType.Date:
       return (
         <DatePicker {...commonProps} onChange={(e: ChangeEvent<HTMLInputElement>): void => onChange(e.target.value)} />

--- a/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
+++ b/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
@@ -402,7 +402,7 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
       const validateComponents = (comps: any[]): any => {
         comps.forEach((comp: any) => {
           if (
-            (comp.type === 'PASSWORD_INPUT' || comp.type === 'TEXT_INPUT' || comp.type === 'EMAIL_INPUT') &&
+            (comp.type === 'PASSWORD_INPUT' || comp.type === 'TEXT_INPUT' || comp.type === 'EMAIL_INPUT' || comp.type === 'PHONE_INPUT' || comp.type === 'OTP_INPUT') &&
             comp.required &&
             comp.ref
           ) {

--- a/packages/react/src/components/presentation/auth/AuthOptionFactory.tsx
+++ b/packages/react/src/components/presentation/auth/AuthOptionFactory.tsx
@@ -110,6 +110,8 @@ const getFieldType = (variant: EmbeddedFlowComponentType): FieldType => {
   switch (variant) {
     case EmbeddedFlowComponentType.EmailInput:
       return FieldType.Email;
+    case EmbeddedFlowComponentType.PhoneInput:
+      return FieldType.Tel;
     case EmbeddedFlowComponentType.PasswordInput:
       return FieldType.Password;
     case EmbeddedFlowComponentType.TextInput:
@@ -224,7 +226,8 @@ const createAuthComponentFromFlow = (
   switch (component.type) {
     case EmbeddedFlowComponentType.TextInput:
     case EmbeddedFlowComponentType.PasswordInput:
-    case EmbeddedFlowComponentType.EmailInput: {
+    case EmbeddedFlowComponentType.EmailInput:
+    case EmbeddedFlowComponentType.PhoneInput: {
       const identifier: string = component.ref;
       const value: string = formValues[identifier] || '';
       const isTouched: boolean = touchedFields[identifier] || false;
@@ -241,6 +244,28 @@ const createAuthComponentFromFlow = (
         placeholder: resolve(component.placeholder) || '',
         required: component.required || false,
         type: fieldType as FieldType,
+        value,
+      });
+
+      return cloneElement(field, {key});
+    }
+
+    case EmbeddedFlowComponentType.OtpInput: {
+      const identifier: string = component.ref;
+      const value: string = formValues[identifier] || '';
+      const isTouched: boolean = touchedFields[identifier] || false;
+      const error: string = isTouched ? formErrors[identifier] : undefined;
+
+      const field: any = createField({
+        className: options.inputClassName,
+        error,
+        label: resolve(component.label) || '',
+        name: identifier,
+        onBlur: () => options.onInputBlur?.(identifier),
+        onChange: (newValue: string) => onInputChange(identifier, newValue),
+        placeholder: resolve(component.placeholder) || '',
+        required: component.required || false,
+        type: FieldType.Otp,
         value,
       });
 

--- a/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
+++ b/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
@@ -343,7 +343,7 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
       const validateComponents = (comps: any[]): any => {
         comps.forEach((comp: any) => {
           if (
-            (comp.type === 'TEXT_INPUT' || comp.type === 'EMAIL_INPUT' || comp.type === 'SELECT') &&
+            (comp.type === 'TEXT_INPUT' || comp.type === 'EMAIL_INPUT' || comp.type === 'SELECT' || comp.type === 'PHONE_INPUT' || comp.type === 'OTP_INPUT') &&
             comp.required &&
             comp.ref
           ) {

--- a/packages/react/src/components/presentation/auth/SignIn/v2/BaseSignIn.tsx
+++ b/packages/react/src/components/presentation/auth/SignIn/v2/BaseSignIn.tsx
@@ -281,7 +281,9 @@ const BaseSignInContent: FC<BaseSignInProps> = ({
           if (
             component.type === 'TEXT_INPUT' ||
             component.type === 'PASSWORD_INPUT' ||
-            component.type === 'EMAIL_INPUT'
+            component.type === 'EMAIL_INPUT' ||
+            component.type === 'PHONE_INPUT' ||
+            component.type === 'OTP_INPUT'
           ) {
             const identifier: string = component.ref;
             fields.push({


### PR DESCRIPTION
## Summary
- Adds `Tel` to `FieldType` enum and renders it as `<input type="tel">` in `FieldFactory`
- Handles `PHONE_INPUT` in `AuthOptionFactory` (field type mapping + rendering case)
- Handles `OTP_INPUT` in `AuthOptionFactory` using existing `FieldType.Otp` / `OtpField`
- Registers `PHONE_INPUT` and `OTP_INPUT` in form field extraction/validation across `BaseSignIn`, `BaseAcceptInvite`, and `BaseInviteUser`

Closes #449
Also fixes https://github.com/asgardeo/thunder/issues/2193

## Test plan
- [ ] Configure a login flow with SMS OTP and verify `PHONE_INPUT` renders as a tel input
- [ ] Verify `OTP_INPUT` renders using the OTP field component after phone submission
- [ ] Verify form validation works for both new input types (required field check)
- [ ] Verify existing input types (text, password, email) are unaffected