### PR TITLE
Request default scopes only when user hasn't explicitly defined

### DIFF
--- a/.changeset/fresh-singers-shake.md
+++ b/.changeset/fresh-singers-shake.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/javascript': minor
+---
+
+Request default scopes only when user hasn't explicitly defined

--- a/packages/javascript/src/utils/__tests__/processOpenIDScopes.test.ts
+++ b/packages/javascript/src/utils/__tests__/processOpenIDScopes.test.ts
@@ -31,46 +31,49 @@ vi.mock('../../constants/OIDCRequestConstants', () => ({
 }));
 
 describe('processOpenIDScopes', () => {
-  it('should return the same string if it already includes all default scopes (no duplicates, preserves order)', () => {
+  it('should return user-configured string scopes exactly as provided (no default injection)', () => {
     const input: string = 'email openid profile';
     const out: string = processOpenIDScopes(input);
     expect(out).toBe('email openid profile');
   });
 
-  it('should add missing default scopes to a string input (appends to the end)', () => {
+  it('should return user-configured string scopes without injecting defaults', () => {
     const input: string = 'profile';
     const out: string = processOpenIDScopes(input);
-
-    expect(out).toBe('profile openid email');
+    expect(out).toBe('profile');
   });
 
-  it('should append only the missing default scopes when some are already present', () => {
-    const input: string = 'email profile';
-    const out: string = processOpenIDScopes(input);
-    expect(out).toBe('email profile openid');
-  });
-
-  it('should join an array of scopes and injects any missing defaults', () => {
+  it('should return user-configured array scopes joined as a string without injecting defaults', () => {
     const input: string[] = ['profile', 'email'];
     const out: string = processOpenIDScopes(input);
-    expect(out).toBe('profile email openid');
+    expect(out).toBe('profile email');
   });
 
-  it('should not duplicate defaults when provided as array', () => {
+  it('should return user-configured array scopes without duplicating values', () => {
     const input: string[] = ['openid', 'email'];
     const out: string = processOpenIDScopes(input);
     expect(out).toBe('openid email');
   });
 
-  it('should handle an empty string by returning only defaults', () => {
+  it('should return only defaults for an empty string (not configured)', () => {
     const input: string = '';
     const out: string = processOpenIDScopes(input);
     expect(out).toBe('openid email');
   });
 
-  it('should handle an empty array by returning only defaults', () => {
+  it('should return only defaults for an empty array (not configured)', () => {
     const input: string[] = [];
     const out: string = processOpenIDScopes(input);
+    expect(out).toBe('openid email');
+  });
+
+  it('should return only defaults when scopes is undefined (not configured)', () => {
+    const out: string = processOpenIDScopes(undefined);
+    expect(out).toBe('openid email');
+  });
+
+  it('should return only defaults when scopes is null (not configured)', () => {
+    const out: string = processOpenIDScopes(null);
     expect(out).toBe('openid email');
   });
 
@@ -82,9 +85,9 @@ describe('processOpenIDScopes', () => {
     expect(() => processOpenIDScopes({})).toThrow(AsgardeoRuntimeError);
   });
 
-  it('should not trim or re-order user-provided string segments beyond default injection', () => {
+  it('should return custom scopes exactly without appending defaults', () => {
     const input: string = 'custom-scope another';
     const out: string = processOpenIDScopes(input);
-    expect(out).toBe('custom-scope another openid email');
+    expect(out).toBe('custom-scope another');
   });
 });

--- a/packages/javascript/src/utils/processOpenIDScopes.ts
+++ b/packages/javascript/src/utils/processOpenIDScopes.ts
@@ -25,25 +25,33 @@ import AsgardeoRuntimeError from '../errors/AsgardeoRuntimeError';
  * If the input is an array, it joins the elements into a single string separated by spaces.
  * If the input is neither, it throws an error.
  *
- * @param scopes - The OpenID scopes to process, which can be a string or an array of strings.
+ * Default scopes are only injected when no scopes are configured (undefined, empty string,
+ * or empty array). If the caller explicitly provides scopes, those are used as-is.
+ *
+ * @param scopes - The OpenID scopes to process, which can be a string, an array of strings,
+ *   or undefined/null when not configured.
  * @returns A string of OpenID scopes separated by spaces.
  *
  * @example
  * ```typescript
  * processOpenIDScopes("openid profile email"); // returns "openid profile email"
  * processOpenIDScopes(["openid", "profile", "email"]); // returns "openid profile email"
+ * processOpenIDScopes(undefined); // returns default scopes
  * processOpenIDScopes(123); // throws AsgardeoRuntimeError
  * processOpenIDScopes({}); // throws AsgardeoRuntimeError
  * ```
  */
-const processOpenIDScopes = (scopes: string | string[]): string => {
+const processOpenIDScopes = (scopes: string | string[] | undefined | null): string => {
   let processedScopes: string[] = [];
+  let userConfiguredScopes: boolean = false;
 
-  if (scopes) {
+  if (scopes !== undefined && scopes !== null) {
     if (Array.isArray(scopes)) {
       processedScopes = scopes;
+      userConfiguredScopes = scopes.length > 0;
     } else if (typeof scopes === 'string') {
-      processedScopes = scopes.split(' ');
+      processedScopes = scopes ? scopes.split(' ') : [];
+      userConfiguredScopes = scopes.length > 0;
     } else {
       throw new AsgardeoRuntimeError(
         'Scopes must be a string or an array of strings.',
@@ -54,11 +62,13 @@ const processOpenIDScopes = (scopes: string | string[]): string => {
     }
   }
 
-  OIDCRequestConstants.SignIn.Payload.DEFAULT_SCOPES.forEach((defaultScope: string) => {
-    if (!processedScopes.includes(defaultScope)) {
-      processedScopes.push(defaultScope);
-    }
-  });
+  if (!userConfiguredScopes) {
+    OIDCRequestConstants.SignIn.Payload.DEFAULT_SCOPES.forEach((defaultScope: string) => {
+      if (!processedScopes.includes(defaultScope)) {
+        processedScopes.push(defaultScope);
+      }
+    });
+  }
 
   return processedScopes.join(' ');
 };

--- a/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
+++ b/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
@@ -402,7 +402,11 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
       const validateComponents = (comps: any[]): any => {
         comps.forEach((comp: any) => {
           if (
-            (comp.type === 'PASSWORD_INPUT' || comp.type === 'TEXT_INPUT' || comp.type === 'EMAIL_INPUT' || comp.type === 'PHONE_INPUT' || comp.type === 'OTP_INPUT') &&
+            (comp.type === 'PASSWORD_INPUT' ||
+              comp.type === 'TEXT_INPUT' ||
+              comp.type === 'EMAIL_INPUT' ||
+              comp.type === 'PHONE_INPUT' ||
+              comp.type === 'OTP_INPUT') &&
             comp.required &&
             comp.ref
           ) {

--- a/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
+++ b/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
@@ -348,7 +348,11 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
       const validateComponents = (comps: any[]): any => {
         comps.forEach((comp: any) => {
           if (
-            (comp.type === 'TEXT_INPUT' || comp.type === 'EMAIL_INPUT' || comp.type === 'SELECT' || comp.type === 'PHONE_INPUT' || comp.type === 'OTP_INPUT') &&
+            (comp.type === 'TEXT_INPUT' ||
+              comp.type === 'EMAIL_INPUT' ||
+              comp.type === 'SELECT' ||
+              comp.type === 'PHONE_INPUT' ||
+              comp.type === 'OTP_INPUT') &&
             comp.required &&
             comp.ref
           ) {


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request updates the `processOpenIDScopes` utility and its tests to change how default OpenID scopes are handled. Now, default scopes are only injected when no scopes are configured (i.e., when the input is `undefined`, `null`, an empty string, or an empty array). If the user provides any scopes, those are used exactly as provided, without adding defaults. The tests and documentation are updated to reflect this new behavior.

**Behavior change:**

* `processOpenIDScopes` now injects default scopes only if no scopes are configured (i.e., input is `undefined`, `null`, empty string, or empty array). If the user provides any scopes (string or array), those are returned as-is, without adding defaults. [[1]](diffhunk://#diff-a329bb509bfed6d38ffc7b16f9b0f09ec208910120766e1166fdc5de27d7f137L28-R54) [[2]](diffhunk://#diff-a329bb509bfed6d38ffc7b16f9b0f09ec208910120766e1166fdc5de27d7f137R65-R71)

**Test updates:**

* Unit tests in `processOpenIDScopes.test.ts` are updated to verify that user-provided scopes are not altered by default injection, and new tests are added for `undefined` and `null` inputs. [[1]](diffhunk://#diff-d2da5ce81a2f101273c66e2c314bbf1100b02456179f26690fdce5b95947a15eL34-R79) [[2]](diffhunk://#diff-d2da5ce81a2f101273c66e2c314bbf1100b02456179f26690fdce5b95947a15eL85-R91)

**Documentation:**

* JSDoc comments for `processOpenIDScopes` are updated to clarify the new behavior and input types.

### Related Issues
- Fixes https://github.com/asgardeo/javascript/issues/453

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
