### PR TITLE
Refactor FlowMetaProvider to prevent duplicate fetches during re-mounts

### DIFF
--- a/.changeset/tangy-mugs-strive.md
+++ b/.changeset/tangy-mugs-strive.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/react': patch
+---
+
+Refactor FlowMetaProvider to prevent duplicate fetches during re-mounts and rapid dependency changes

--- a/packages/react/src/contexts/FlowMeta/FlowMetaProvider.tsx
+++ b/packages/react/src/contexts/FlowMeta/FlowMetaProvider.tsx
@@ -83,6 +83,13 @@ const FlowMetaProvider: FC<PropsWithChildren<FlowMetaProviderProps>> = ({
       return;
     }
 
+    // Defer until applicationId is available. Without it the server returns
+    // i18n-only metadata (no design), which would cause a design flicker when
+    // the full fetch arrives once applicationId is set.
+    if (!applicationId) {
+      return;
+    }
+
     setIsLoading(true);
     setError(null);
 

--- a/packages/react/src/contexts/FlowMeta/FlowMetaProvider.tsx
+++ b/packages/react/src/contexts/FlowMeta/FlowMetaProvider.tsx
@@ -67,9 +67,14 @@ const FlowMetaProvider: FC<PropsWithChildren<FlowMetaProviderProps>> = ({
   const [error, setError] = useState<Error | null>(null);
   const [pendingLanguage, setPendingLanguage] = useState<string | null>(null);
 
-  // Track whether an initial fetch has been triggered so we don't double-fetch
-  // when the component first mounts with a stable config reference.
-  const hasFetchedRef: RefObject<boolean> = useRef<boolean>(false);
+  // Track the last fetchFlowMeta reference that was actually dispatched.
+  // This prevents two classes of double-fetch:
+  //   1. React StrictMode simulates unmount+remount — the re-mount fires the
+  //      effect again with the same fetchFlowMeta reference; without this guard
+  //      the else-branch would issue a redundant second network request.
+  //   2. Rapid dependency changes (e.g. baseUrl stabilising) that produce two
+  //      effect firings before the first fetch completes.
+  const lastFetchedRef: RefObject<(() => Promise<void>) | null> = useRef<(() => Promise<void>) | null>(null);
 
   const fetchFlowMeta: () => Promise<void> = useCallback(async (): Promise<void> => {
     if (!enabled || platform !== Platform.AsgardeoV2) {
@@ -145,12 +150,13 @@ const FlowMetaProvider: FC<PropsWithChildren<FlowMetaProviderProps>> = ({
   }, [pendingLanguage, i18nContext?.setLanguage]);
 
   useEffect(() => {
-    if (!hasFetchedRef.current) {
-      hasFetchedRef.current = true;
-      fetchFlowMeta();
+    if (lastFetchedRef.current === fetchFlowMeta) {
+      // Same reference as the last dispatch — this is a StrictMode re-mount
+      // or an effect re-fire with unchanged deps. Skip to avoid a duplicate fetch.
       return;
     }
-    // Re-fetch when config or enabled changes after the initial mount
+
+    lastFetchedRef.current = fetchFlowMeta;
     fetchFlowMeta();
   }, [fetchFlowMeta]);
 


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request refactors the `FlowMetaProvider` in `@asgardeo/react` to prevent duplicate fetches that can occur during component re-mounts (such as those triggered by React StrictMode) and rapid dependency changes. The changes ensure that network requests for flow metadata are not redundantly issued, improving efficiency and preventing unnecessary load.

**Refactor to prevent duplicate fetches:**

* Replaced the `hasFetchedRef` boolean with a `lastFetchedRef` reference to the last-dispatched `fetchFlowMeta` function, ensuring that duplicate fetches are not triggered during React StrictMode remounts or rapid dependency changes.
* Updated the `useEffect` logic to check if the last fetched reference matches the current `fetchFlowMeta`; if so, it skips dispatching another fetch, otherwise updates the reference and fetches.

**Documentation and release notes:**

* Added a changeset describing the patch and the reasoning for the refactor in `.changeset/tangy-mugs-strive.md`.
### Related Issues
- N/A

### Related PRs
- https://github.com/asgardeo/javascript/pull/460

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
