### PR TITLE
Refactor FlowMetaProvider to defer metadata fetch until Asgardeo initialization is complete

### DIFF
--- a/.changeset/eager-meals-pull.md
+++ b/.changeset/eager-meals-pull.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/react': patch
+---
+
+Refactor FlowMetaProvider to defer metadata fetch until Asgardeo initialization is complete

--- a/packages/react/src/contexts/FlowMeta/FlowMetaProvider.tsx
+++ b/packages/react/src/contexts/FlowMeta/FlowMetaProvider.tsx
@@ -59,7 +59,7 @@ const FlowMetaProvider: FC<PropsWithChildren<FlowMetaProviderProps>> = ({
   children,
   enabled = true,
 }: PropsWithChildren<FlowMetaProviderProps>): ReactElement => {
-  const {baseUrl, applicationId, platform} = useAsgardeo();
+  const {baseUrl, applicationId, platform, isInitialized} = useAsgardeo();
   const i18nContext: I18nContextValue = useI18n();
 
   const [meta, setMeta] = useState<FlowMetadataResponse | null>(null);
@@ -83,10 +83,10 @@ const FlowMetaProvider: FC<PropsWithChildren<FlowMetaProviderProps>> = ({
       return;
     }
 
-    // Defer until applicationId is available. Without it the server returns
-    // i18n-only metadata (no design), which would cause a design flicker when
-    // the full fetch arrives once applicationId is set.
-    if (!applicationId) {
+    // Defer until Asgardeo finishes initializing (e.g. loading applicationId
+    // from storage on refresh). Once initialized, proceed even if applicationId
+    // is absent — some flows (e.g. AcceptInvite) have no applicationId by design.
+    if (!isInitialized && !applicationId) {
       return;
     }
 
@@ -105,7 +105,7 @@ const FlowMetaProvider: FC<PropsWithChildren<FlowMetaProviderProps>> = ({
     } finally {
       setIsLoading(false);
     }
-  }, [enabled, platform, baseUrl, applicationId, i18nContext?.currentLanguage]);
+  }, [enabled, platform, baseUrl, applicationId, isInitialized, i18nContext?.currentLanguage]);
 
   const switchLanguage: (language: string) => Promise<void> = useCallback(
     async (language: string): Promise<void> => {


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request updates the `FlowMetaProvider` component in `FlowMetaProvider.tsx` to improve how it handles the initialization state of the Asgardeo authentication context. The main goal is to ensure that metadata fetching waits until Asgardeo is fully initialized, preventing unnecessary UI flickers and supporting flows that may not have an `applicationId`.

**Improvements to initialization and metadata fetching logic:**

- The `isInitialized` property from `useAsgardeo` is now used in addition to `applicationId` to determine when to fetch flow metadata, ensuring that fetching only occurs after Asgardeo is ready. This prevents design flicker and supports flows without an `applicationId` (e.g., AcceptInvite). [[1]](diffhunk://#diff-6bd603d34e882b1883d94130444cc59fa922bdc96a713457dc984918f653962bL62-R62) [[2]](diffhunk://#diff-6bd603d34e882b1883d94130444cc59fa922bdc96a713457dc984918f653962bL86-R89)
- The effect dependencies for fetching metadata have been updated to include `isInitialized`, ensuring the effect reacts to changes in initialization state.

### Related Issues
- N/A

### Related PRs
- https://github.com/asgardeo/javascript/pull/462

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
