### PR TITLE
[V2] Support per step challenge token

### DIFF
--- a/.changeset/three-flowers-sneeze.md
+++ b/.changeset/three-flowers-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@asgardeo/javascript': patch
+'@asgardeo/react': patch
+---
+
+Add support for optional per step challenge token

--- a/packages/javascript/src/models/v2/embedded-signin-flow-v2.ts
+++ b/packages/javascript/src/models/v2/embedded-signin-flow-v2.ts
@@ -167,6 +167,12 @@ export interface ExtendedEmbeddedSignInFlowResponse {
  */
 export interface EmbeddedSignInFlowResponse extends ExtendedEmbeddedSignInFlowResponse {
   /**
+   * Per-step challenge token for replay protection.
+   * Must be included in the next request to continue this flow.
+   */
+  challengeToken?: string;
+
+  /**
    * Core response data containing UI components and flow metadata.
    * Includes both modern meta.components structure and legacy fields for compatibility.
    */
@@ -322,6 +328,12 @@ export interface EmbeddedSignInFlowRequest extends Partial<EmbeddedSignInFlowIni
    * Corresponds to action components in the UI (e.g., submit button, social login).
    */
   action?: string;
+
+  /**
+   * Per-step challenge token received from the previous flow response.
+   * Required when continuing an existing flow to prevent replay attacks.
+   */
+  challengeToken?: string;
 
   /**
    * Identifier of the flow instance to continue.

--- a/packages/javascript/src/models/v2/embedded-signup-flow-v2.ts
+++ b/packages/javascript/src/models/v2/embedded-signup-flow-v2.ts
@@ -142,6 +142,12 @@ export interface ExtendedEmbeddedSignUpFlowResponse {
  */
 export interface EmbeddedSignUpFlowResponse extends ExtendedEmbeddedSignUpFlowResponse {
   /**
+   * Per-step challenge token for replay protection.
+   * Must be included in the next request to continue this flow.
+   */
+  challengeToken?: string;
+
+  /**
    * Flow data containing form inputs and available actions.
    * This is transformed to component-driven format by the React transformer.
    */
@@ -210,6 +216,7 @@ export type EmbeddedSignUpFlowInitiateRequest = {
  */
 export interface EmbeddedSignUpFlowRequest extends Partial<EmbeddedSignUpFlowInitiateRequest> {
   action?: string;
+  challengeToken?: string;
   executionId?: string;
   inputs?: Record<string, any>;
 }

--- a/packages/react/src/AsgardeoReactClient.ts
+++ b/packages/react/src/AsgardeoReactClient.ts
@@ -560,6 +560,10 @@ class AsgardeoReactClient<T extends AsgardeoReactConfig = AsgardeoReactConfig> e
     return (await this.asgardeo.getStorageManager()).setSessionData(sessionData, sessionId);
   }
 
+  async getStorageManager(): Promise<any> {
+    return this.asgardeo.getStorageManager();
+  }
+
   override decodeJwtToken<TResult = Record<string, unknown>>(token: string): Promise<TResult> {
     return this.asgardeo.decodeJwtToken<TResult>(token);
   }

--- a/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
+++ b/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
@@ -38,6 +38,7 @@ import {renderInviteUserComponents} from '../../AuthOptionFactory';
  * Flow response structure from the backend.
  */
 export interface AcceptInviteFlowResponse {
+  challengeToken?: string;
   data?: {
     additionalData?: Record<string, string>;
     components?: any[];
@@ -464,6 +465,7 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
           executionId: currentFlow.executionId,
           inputs,
           verbose: true,
+          ...(currentFlow.challengeToken ? {challengeToken: currentFlow.challengeToken} : {}),
         };
 
         // Add action ID if component has one

--- a/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
+++ b/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
@@ -263,7 +263,7 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
   showTitle = true,
   showSubtitle = true,
 }: BaseAcceptInviteProps): ReactElement => {
-  const {meta, isInitialized, getChallengeToken, setChallengeToken: persistChallengeToken} = useAsgardeo();
+  const {meta, isInitialized, getStorageManager} = useAsgardeo();
   const {t} = useTranslation(preferences?.i18n);
   const {theme} = useTheme();
   const styles: any = useStyles(theme, theme.vars.colors.text.primary);
@@ -291,9 +291,10 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
 
     (async (): Promise<void> => {
       try {
-        const token: string | null = await getChallengeToken();
-        if (token) {
-          challengeTokenRef.current = token;
+        const storageManager: any = await getStorageManager();
+        const tempData: any = await storageManager?.getTemporaryData();
+        if (tempData?.challengeToken) {
+          challengeTokenRef.current = tempData.challengeToken as string;
         }
       } finally {
         setIsStorageReady(true);
@@ -307,7 +308,14 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
    */
   const setChallengeToken = async (challengeToken: string | null): Promise<void> => {
     challengeTokenRef.current = challengeToken;
-    await persistChallengeToken(challengeToken);
+    const storageManager: any = await getStorageManager();
+    if (storageManager) {
+      if (challengeToken) {
+        await storageManager.setTemporaryDataParameter('challengeToken', challengeToken);
+      } else {
+        await storageManager.removeTemporaryDataParameter('challengeToken');
+      }
+    }
   };
 
   /**

--- a/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
+++ b/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
@@ -263,7 +263,7 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
   showTitle = true,
   showSubtitle = true,
 }: BaseAcceptInviteProps): ReactElement => {
-  const {meta} = useAsgardeo();
+  const {meta, isInitialized, getChallengeToken, setChallengeToken: persistChallengeToken} = useAsgardeo();
   const {t} = useTranslation(preferences?.i18n);
   const {theme} = useTheme();
   const styles: any = useStyles(theme, theme.vars.colors.text.primary);
@@ -277,8 +277,38 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
   const [touchedFields, setTouchedFields] = useState<Record<string, boolean>>({});
   const [isFormValid, setIsFormValid] = useState(true);
+  const [isStorageReady, setIsStorageReady] = useState(false);
+  const challengeTokenRef: any = useRef<string | null>(null);
 
   const tokenValidationAttemptedRef: any = useRef(false);
+
+  /**
+   * Restore any challenge token persisted before an OAuth redirect.
+   * Waits for SDK initialization before reading from storage.
+   */
+  useEffect(() => {
+    if (!isInitialized) return;
+
+    (async (): Promise<void> => {
+      try {
+        const token: string | null = await getChallengeToken();
+        if (token) {
+          challengeTokenRef.current = token;
+        }
+      } finally {
+        setIsStorageReady(true);
+      }
+    })();
+  }, [isInitialized]);
+
+  /**
+   * Updates challengeTokenRef immediately (stale-closure safe) and persists via
+   * the provider's StorageManager so the token survives OAuth redirects.
+   */
+  const setChallengeToken = async (challengeToken: string | null): Promise<void> => {
+    challengeTokenRef.current = challengeToken;
+    await persistChallengeToken(challengeToken);
+  };
 
   /**
    * Handle error responses and extract meaningful error messages.
@@ -341,7 +371,7 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
    */
   useOAuthCallback({
     currentExecutionId: executionId ?? null,
-    isInitialized: true,
+    isInitialized: isStorageReady,
     onComplete: () => {
       setIsValidatingToken(false);
       onComplete?.();
@@ -365,8 +395,12 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
       setIsValidatingToken(true);
     },
     onSubmit: async (payload: any) => {
-      const rawResponse: any = await onSubmit(payload);
+      const rawResponse: any = await onSubmit({
+        ...payload,
+        ...(challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : {}),
+      });
       const response: any = normalizeFlowResponseLocal(rawResponse);
+      await setChallengeToken(response.challengeToken ?? null);
       return response;
     },
     tokenValidationAttemptedRef,
@@ -465,7 +499,7 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
           executionId: currentFlow.executionId,
           inputs,
           verbose: true,
-          ...(currentFlow.challengeToken ? {challengeToken: currentFlow.challengeToken} : {}),
+          ...(challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : {}),
         };
 
         // Add action ID if component has one
@@ -476,6 +510,8 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
         const rawResponse: any = await onSubmit(payload);
         const response: any = normalizeFlowResponseLocal(rawResponse);
         onFlowChange?.(response);
+
+        await setChallengeToken(response.challengeToken ?? null);
 
         // Handle OAuth redirect response
         if (response.type === 'REDIRECTION') {
@@ -568,6 +604,8 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
         const rawResponse: any = await onSubmit(payload);
         const response: any = normalizeFlowResponseLocal(rawResponse);
         onFlowChange?.(response);
+
+        await setChallengeToken(response.challengeToken ?? null);
 
         // Check for error (invalid token)
         if (response.flowStatus === 'ERROR') {

--- a/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
+++ b/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
@@ -249,12 +249,7 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
   showTitle = true,
   showSubtitle = true,
 }: BaseInviteUserProps): ReactElement => {
-  const {
-    meta,
-    isInitialized: isSdkInitialized,
-    getChallengeToken,
-    setChallengeToken: persistChallengeToken,
-  } = useAsgardeo();
+  const {meta, isInitialized: isSdkInitialized, getStorageManager} = useAsgardeo();
   const {t} = useTranslation(preferences?.i18n);
   const {theme} = useTheme();
   const styles: any = useStyles(theme, theme.vars.colors.text.primary);
@@ -278,9 +273,10 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
 
     (async (): Promise<void> => {
       try {
-        const token: string | null = await getChallengeToken();
-        if (token) {
-          challengeTokenRef.current = token;
+        const storageManager: any = await getStorageManager();
+        const tempData: any = await storageManager?.getTemporaryData();
+        if (tempData?.challengeToken) {
+          challengeTokenRef.current = tempData.challengeToken as string;
         }
       } catch {
         // StorageManager unavailable — continue without persisted token
@@ -294,7 +290,14 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
    */
   const setChallengeToken = async (challengeToken: string | null): Promise<void> => {
     challengeTokenRef.current = challengeToken;
-    await persistChallengeToken(challengeToken);
+    const storageManager: any = await getStorageManager();
+    if (storageManager) {
+      if (challengeToken) {
+        await storageManager.setTemporaryDataParameter('challengeToken', challengeToken);
+      } else {
+        await storageManager.removeTemporaryDataParameter('challengeToken');
+      }
+    }
   };
 
   /**

--- a/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
+++ b/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
@@ -16,7 +16,13 @@
  * under the License.
  */
 
-import {EmbeddedFlowType, FlowMetadataResponse, OrganizationUnitListResponse, Preferences} from '@asgardeo/browser';
+import {
+  EmbeddedFlowType,
+  FlowMetadataResponse,
+  logger,
+  OrganizationUnitListResponse,
+  Preferences,
+} from '@asgardeo/browser';
 import {cx} from '@emotion/css';
 import {FC, ReactElement, ReactNode, useCallback, useEffect, useRef, useState} from 'react';
 import useStyles from './BaseInviteUser.styles';
@@ -290,13 +296,17 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
    */
   const setChallengeToken = async (challengeToken: string | null): Promise<void> => {
     challengeTokenRef.current = challengeToken;
-    const storageManager: any = await getStorageManager();
-    if (storageManager) {
-      if (challengeToken) {
-        await storageManager.setTemporaryDataParameter('challengeToken', challengeToken);
-      } else {
-        await storageManager.removeTemporaryDataParameter('challengeToken');
+    try {
+      const storageManager: any = await getStorageManager();
+      if (storageManager) {
+        if (challengeToken) {
+          await storageManager.setTemporaryDataParameter('challengeToken', challengeToken);
+        } else {
+          await storageManager.removeTemporaryDataParameter('challengeToken');
+        }
       }
+    } catch {
+      logger.warn('Failed to persist challenge token in storage.');
     }
   };
 

--- a/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
+++ b/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
@@ -35,6 +35,7 @@ import {renderInviteUserComponents} from '../../AuthOptionFactory';
  * Flow response structure from the backend.
  */
 export interface InviteUserFlowResponse {
+  challengeToken?: string;
   data?: {
     additionalData?: Record<string, any>;
     components?: any[];
@@ -415,6 +416,7 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
           executionId: currentFlow.executionId,
           inputs,
           verbose: true,
+          ...(currentFlow.challengeToken ? {challengeToken: currentFlow.challengeToken} : {}),
         };
 
         // Add action ID if component has one

--- a/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
+++ b/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
@@ -249,7 +249,12 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
   showTitle = true,
   showSubtitle = true,
 }: BaseInviteUserProps): ReactElement => {
-  const {meta} = useAsgardeo();
+  const {
+    meta,
+    isInitialized: isSdkInitialized,
+    getChallengeToken,
+    setChallengeToken: persistChallengeToken,
+  } = useAsgardeo();
   const {t} = useTranslation(preferences?.i18n);
   const {theme} = useTheme();
   const styles: any = useStyles(theme, theme.vars.colors.text.primary);
@@ -261,8 +266,36 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
   const [touchedFields, setTouchedFields] = useState<Record<string, boolean>>({});
   const [isFormValid, setIsFormValid] = useState(true);
+  const challengeTokenRef: any = useRef<string | null>(null);
 
   const initializationAttemptedRef: any = useRef(false);
+
+  /**
+   * Restore any challenge token persisted before an OAuth redirect.
+   */
+  useEffect(() => {
+    if (!isSdkInitialized) return;
+
+    (async (): Promise<void> => {
+      try {
+        const token: string | null = await getChallengeToken();
+        if (token) {
+          challengeTokenRef.current = token;
+        }
+      } catch {
+        // StorageManager unavailable — continue without persisted token
+      }
+    })();
+  }, [isSdkInitialized]);
+
+  /**
+   * Updates challengeTokenRef immediately (stale-closure safe) and persists via
+   * the provider's StorageManager so the token survives OAuth redirects.
+   */
+  const setChallengeToken = async (challengeToken: string | null): Promise<void> => {
+    challengeTokenRef.current = challengeToken;
+    await persistChallengeToken(challengeToken);
+  };
 
   /**
    * Handle error responses and extract meaningful error messages.
@@ -416,7 +449,7 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
           executionId: currentFlow.executionId,
           inputs,
           verbose: true,
-          ...(currentFlow.challengeToken ? {challengeToken: currentFlow.challengeToken} : {}),
+          ...(challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : {}),
         };
 
         // Add action ID if component has one
@@ -427,6 +460,8 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
         const rawResponse: any = await onSubmit(payload);
         const response: any = normalizeFlowResponseLocal(rawResponse);
         onFlowChange?.(response);
+
+        await setChallengeToken(response.challengeToken ?? null);
 
         // Check for error status
         if (response.flowStatus === 'ERROR') {
@@ -480,6 +515,7 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
 
           const rawResponse: any = await onInitialize(payload);
           const response: any = normalizeFlowResponseLocal(rawResponse);
+          await setChallengeToken(response.challengeToken ?? null);
           setCurrentFlow(response);
           setIsFlowInitialized(true);
           onFlowChange?.(response);

--- a/packages/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
+++ b/packages/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
@@ -216,16 +216,7 @@ const SignIn: FC<SignInProps> = ({
   variant,
   children,
 }: SignInProps): ReactElement => {
-  const {
-    applicationId,
-    afterSignInUrl,
-    signIn,
-    isInitialized,
-    isLoading,
-    meta,
-    getChallengeToken,
-    setChallengeToken: persistChallengeToken,
-  } = useAsgardeo();
+  const {applicationId, afterSignInUrl, signIn, isInitialized, isLoading, meta, getStorageManager} = useAsgardeo();
   const {t} = useTranslation(preferences?.i18n);
 
   // State management for the flow
@@ -271,9 +262,10 @@ const SignIn: FC<SignInProps> = ({
 
     (async (): Promise<void> => {
       try {
-        const token: string | null = await getChallengeToken();
-        if (token) {
-          challengeTokenRef.current = token;
+        const storageManager: any = await getStorageManager();
+        const tempData: any = await storageManager?.getTemporaryData();
+        if (tempData?.challengeToken) {
+          challengeTokenRef.current = tempData.challengeToken as string;
         }
       } finally {
         setIsStorageReady(true);
@@ -287,7 +279,14 @@ const SignIn: FC<SignInProps> = ({
    */
   const setChallengeToken = async (challengeToken: string | null): Promise<void> => {
     challengeTokenRef.current = challengeToken;
-    await persistChallengeToken(challengeToken);
+    const storageManager: any = await getStorageManager();
+    if (storageManager) {
+      if (challengeToken) {
+        await storageManager.setTemporaryDataParameter('challengeToken', challengeToken);
+      } else {
+        await storageManager.removeTemporaryDataParameter('challengeToken');
+      }
+    }
   };
 
   /**

--- a/packages/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
+++ b/packages/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
@@ -216,16 +216,24 @@ const SignIn: FC<SignInProps> = ({
   variant,
   children,
 }: SignInProps): ReactElement => {
-  const {applicationId, afterSignInUrl, signIn, isInitialized, isLoading, meta} = useAsgardeo();
+  const {
+    applicationId,
+    afterSignInUrl,
+    signIn,
+    isInitialized,
+    isLoading,
+    meta,
+    getChallengeToken,
+    setChallengeToken: persistChallengeToken,
+  } = useAsgardeo();
   const {t} = useTranslation(preferences?.i18n);
 
   // State management for the flow
   const [components, setComponents] = useState<EmbeddedFlowComponent[]>([]);
   const [additionalData, setAdditionalData] = useState<Record<string, any>>({});
   const [currentExecutionId, setCurrentExecutionId] = useState<string | null>(null);
-  const [currentChallengeToken, setCurrentChallengeToken] = useState<string | null>(() =>
-    sessionStorage.getItem('asgardeo_challenge_token'),
-  );
+  const challengeTokenRef: any = useRef<string | null>(null);
+  const [isStorageReady, setIsStorageReady] = useState(false);
   const [isFlowInitialized, setIsFlowInitialized] = useState(false);
   const [flowError, setFlowError] = useState<Error | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -255,24 +263,39 @@ const SignIn: FC<SignInProps> = ({
   };
 
   /**
-   * Sets challengeToken between sessionStorage and state.
-   * This ensures both are always in sync.
+   * Restore any challenge token persisted before an OAuth redirect.
+   * Waits for SDK initialization before reading from storage.
    */
-  const setChallengeToken = (challengeToken: string | null): void => {
-    setCurrentChallengeToken(challengeToken);
-    if (challengeToken) {
-      sessionStorage.setItem('asgardeo_challenge_token', challengeToken);
-    } else {
-      sessionStorage.removeItem('asgardeo_challenge_token');
-    }
+  useEffect(() => {
+    if (!isInitialized) return;
+
+    (async (): Promise<void> => {
+      try {
+        const token: string | null = await getChallengeToken();
+        if (token) {
+          challengeTokenRef.current = token;
+        }
+      } finally {
+        setIsStorageReady(true);
+      }
+    })();
+  }, [isInitialized]);
+
+  /**
+   * Updates challengeTokenRef immediately (stale-closure safe) and persists via
+   * the provider's StorageManager so the token survives OAuth redirects.
+   */
+  const setChallengeToken = async (challengeToken: string | null): Promise<void> => {
+    challengeTokenRef.current = challengeToken;
+    await persistChallengeToken(challengeToken);
   };
 
   /**
    * Clear all flow-related storage and state.
    */
-  const clearFlowState = (): void => {
+  const clearFlowState = async (): Promise<void> => {
     setExecutionId(null);
-    setChallengeToken(null);
+    await setChallengeToken(null);
     setIsFlowInitialized(false);
     sessionStorage.removeItem('asgardeo_auth_id');
     setIsTimeoutDisabled(false);
@@ -361,7 +384,7 @@ const SignIn: FC<SignInProps> = ({
   /**
    * Handle REDIRECTION response by storing flow state and redirecting to OAuth provider.
    */
-  const handleRedirection = (response: EmbeddedSignInFlowResponseV2): boolean => {
+  const handleRedirection = async (response: EmbeddedSignInFlowResponseV2): Promise<boolean> => {
     if (response.type === EmbeddedSignInFlowTypeV2.Redirection) {
       const redirectURL: any = (response.data as any)?.redirectURL || (response as any)?.redirectURL;
 
@@ -369,7 +392,7 @@ const SignIn: FC<SignInProps> = ({
         if (response.executionId) {
           setExecutionId(response.executionId);
         }
-        setChallengeToken(response.challengeToken ?? null);
+        await setChallengeToken(response.challengeToken ?? null);
 
         const urlParams: any = getUrlParams();
         handleAuthId(urlParams.authId);
@@ -421,7 +444,7 @@ const SignIn: FC<SignInProps> = ({
         })) as EmbeddedSignInFlowResponseV2;
       }
 
-      if (handleRedirection(response)) {
+      if (await handleRedirection(response)) {
         return;
       }
 
@@ -438,9 +461,10 @@ const SignIn: FC<SignInProps> = ({
         meta,
       );
 
+      await setChallengeToken(response.challengeToken ?? null);
+
       if (normalizedExecutionId && normalizedComponents) {
         setExecutionId(normalizedExecutionId);
-        setChallengeToken(response.challengeToken ?? null);
         setComponents(normalizedComponents);
         setAdditionalData(normalizedAdditionalData ?? {});
         setIsFlowInitialized(true);
@@ -450,7 +474,7 @@ const SignIn: FC<SignInProps> = ({
       }
     } catch (error) {
       const err: any = error as any;
-      clearFlowState();
+      await clearFlowState();
 
       // Extract error message from response or error object
       const errorMessage: any = err?.failureReason || (err instanceof Error ? err.message : String(err));
@@ -614,10 +638,10 @@ const SignIn: FC<SignInProps> = ({
         executionId: effectiveExecutionId,
         ...payload,
         inputs: processedInputs,
-        ...(currentChallengeToken ? {challengeToken: currentChallengeToken} : {}),
+        ...(challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : {}),
       })) as EmbeddedSignInFlowResponseV2;
 
-      if (handleRedirection(response)) {
+      if (await handleRedirection(response)) {
         return;
       }
       if (
@@ -630,7 +654,7 @@ const SignIn: FC<SignInProps> = ({
         // Reset passkey processed ref to allow processing
         passkeyProcessedRef.current = false;
 
-        setChallengeToken(response.challengeToken ?? null);
+        await setChallengeToken(response.challengeToken ?? null);
 
         // Set passkey state to trigger the passkey
         setPasskeyState({
@@ -661,7 +685,7 @@ const SignIn: FC<SignInProps> = ({
 
       // Handle Error flow status - flow has failed and is invalidated
       if (response.flowStatus === EmbeddedSignInFlowStatusV2.Error) {
-        clearFlowState();
+        await clearFlowState();
         // Extract failureReason from response if available
         const failureReason: any = (response as any)?.failureReason;
         const errorMessage: any = failureReason || 'Authentication flow failed. Please try again.';
@@ -682,7 +706,7 @@ const SignIn: FC<SignInProps> = ({
 
         // Clear all OAuth-related storage on successful completion
         setExecutionId(null);
-        setChallengeToken(null);
+        await setChallengeToken(null);
         setIsFlowInitialized(false);
         sessionStorage.removeItem('asgardeo_execution_id');
         sessionStorage.removeItem('asgardeo_auth_id');
@@ -704,10 +728,12 @@ const SignIn: FC<SignInProps> = ({
         return;
       }
 
+      // Always update challenge token on any INCOMPLETE response — token rotates every step.
+      await setChallengeToken(response.challengeToken ?? null);
+
       // Update executionId if response contains a new one
       if (normalizedExecutionId && normalizedComponents) {
         setExecutionId(normalizedExecutionId);
-        setChallengeToken(response.challengeToken ?? null);
         setComponents(normalizedComponents);
         setAdditionalData(normalizedAdditionalData ?? {});
         setIsTimeoutDisabled(false);
@@ -723,7 +749,7 @@ const SignIn: FC<SignInProps> = ({
       }
     } catch (error) {
       const err: any = error as any;
-      clearFlowState();
+      await clearFlowState();
 
       // Extract error message from response or error object
       const errorMessage: any = err?.failureReason || (err instanceof Error ? err.message : String(err));
@@ -744,7 +770,7 @@ const SignIn: FC<SignInProps> = ({
 
   useOAuthCallback({
     currentExecutionId,
-    isInitialized: isInitialized && !isLoading,
+    isInitialized: isInitialized && !isLoading && isStorageReady,
     isSubmitting,
     onError: (err: any) => {
       clearFlowState();

--- a/packages/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
+++ b/packages/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
@@ -26,6 +26,7 @@ import {
   EmbeddedSignInFlowTypeV2,
   FlowMetadataResponse,
   Preferences,
+  logger,
 } from '@asgardeo/browser';
 import {FC, ReactElement, useState, useEffect, useRef, ReactNode} from 'react';
 // eslint-disable-next-line import/no-named-as-default
@@ -279,13 +280,17 @@ const SignIn: FC<SignInProps> = ({
    */
   const setChallengeToken = async (challengeToken: string | null): Promise<void> => {
     challengeTokenRef.current = challengeToken;
-    const storageManager: any = await getStorageManager();
-    if (storageManager) {
-      if (challengeToken) {
-        await storageManager.setTemporaryDataParameter('challengeToken', challengeToken);
-      } else {
-        await storageManager.removeTemporaryDataParameter('challengeToken');
+    try {
+      const storageManager: any = await getStorageManager();
+      if (storageManager) {
+        if (challengeToken) {
+          await storageManager.setTemporaryDataParameter('challengeToken', challengeToken);
+        } else {
+          await storageManager.removeTemporaryDataParameter('challengeToken');
+        }
       }
+    } catch {
+      logger.warn('Failed to persist challenge token in storage.');
     }
   };
 

--- a/packages/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
+++ b/packages/react/src/components/presentation/auth/SignIn/v2/SignIn.tsx
@@ -223,6 +223,9 @@ const SignIn: FC<SignInProps> = ({
   const [components, setComponents] = useState<EmbeddedFlowComponent[]>([]);
   const [additionalData, setAdditionalData] = useState<Record<string, any>>({});
   const [currentExecutionId, setCurrentExecutionId] = useState<string | null>(null);
+  const [currentChallengeToken, setCurrentChallengeToken] = useState<string | null>(() =>
+    sessionStorage.getItem('asgardeo_challenge_token'),
+  );
   const [isFlowInitialized, setIsFlowInitialized] = useState(false);
   const [flowError, setFlowError] = useState<Error | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -252,10 +255,24 @@ const SignIn: FC<SignInProps> = ({
   };
 
   /**
+   * Sets challengeToken between sessionStorage and state.
+   * This ensures both are always in sync.
+   */
+  const setChallengeToken = (challengeToken: string | null): void => {
+    setCurrentChallengeToken(challengeToken);
+    if (challengeToken) {
+      sessionStorage.setItem('asgardeo_challenge_token', challengeToken);
+    } else {
+      sessionStorage.removeItem('asgardeo_challenge_token');
+    }
+  };
+
+  /**
    * Clear all flow-related storage and state.
    */
   const clearFlowState = (): void => {
     setExecutionId(null);
+    setChallengeToken(null);
     setIsFlowInitialized(false);
     sessionStorage.removeItem('asgardeo_auth_id');
     setIsTimeoutDisabled(false);
@@ -352,6 +369,7 @@ const SignIn: FC<SignInProps> = ({
         if (response.executionId) {
           setExecutionId(response.executionId);
         }
+        setChallengeToken(response.challengeToken ?? null);
 
         const urlParams: any = getUrlParams();
         handleAuthId(urlParams.authId);
@@ -422,6 +440,7 @@ const SignIn: FC<SignInProps> = ({
 
       if (normalizedExecutionId && normalizedComponents) {
         setExecutionId(normalizedExecutionId);
+        setChallengeToken(response.challengeToken ?? null);
         setComponents(normalizedComponents);
         setAdditionalData(normalizedAdditionalData ?? {});
         setIsFlowInitialized(true);
@@ -595,6 +614,7 @@ const SignIn: FC<SignInProps> = ({
         executionId: effectiveExecutionId,
         ...payload,
         inputs: processedInputs,
+        ...(currentChallengeToken ? {challengeToken: currentChallengeToken} : {}),
       })) as EmbeddedSignInFlowResponseV2;
 
       if (handleRedirection(response)) {
@@ -609,6 +629,8 @@ const SignIn: FC<SignInProps> = ({
 
         // Reset passkey processed ref to allow processing
         passkeyProcessedRef.current = false;
+
+        setChallengeToken(response.challengeToken ?? null);
 
         // Set passkey state to trigger the passkey
         setPasskeyState({
@@ -660,6 +682,7 @@ const SignIn: FC<SignInProps> = ({
 
         // Clear all OAuth-related storage on successful completion
         setExecutionId(null);
+        setChallengeToken(null);
         setIsFlowInitialized(false);
         sessionStorage.removeItem('asgardeo_execution_id');
         sessionStorage.removeItem('asgardeo_auth_id');
@@ -684,6 +707,7 @@ const SignIn: FC<SignInProps> = ({
       // Update executionId if response contains a new one
       if (normalizedExecutionId && normalizedComponents) {
         setExecutionId(normalizedExecutionId);
+        setChallengeToken(response.challengeToken ?? null);
         setComponents(normalizedComponents);
         setAdditionalData(normalizedAdditionalData ?? {});
         setIsTimeoutDisabled(false);

--- a/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
+++ b/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
@@ -675,6 +675,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
         ...((currentFlow as any).executionId && {executionId: (currentFlow as any).executionId}),
         flowType: (currentFlow as any).flowType || 'REGISTRATION',
         ...(component.id && {action: component.id}),
+        ...((currentFlow as any).challengeToken && {challengeToken: (currentFlow as any).challengeToken}),
         inputs: filteredInputs,
       } as any;
 

--- a/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
+++ b/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
@@ -274,12 +274,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
   const {theme, colorScheme} = useTheme();
   const {t} = useTranslation();
   const {subtitle: flowSubtitle, title: flowTitle, messages: flowMessages, addMessage, clearMessages} = useFlow();
-  const {
-    meta,
-    isInitialized: isSdkInitialized,
-    getChallengeToken,
-    setChallengeToken: persistChallengeToken,
-  } = useAsgardeo();
+  const {meta, isInitialized: isSdkInitialized, getStorageManager} = useAsgardeo();
   const styles: any = useStyles(theme, colorScheme);
 
   const [isLoading, setIsLoading] = useState(false);
@@ -306,9 +301,10 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
 
     (async (): Promise<void> => {
       try {
-        const token: string | null = await getChallengeToken();
-        if (token) {
-          challengeTokenRef.current = token;
+        const storageManager: any = await getStorageManager();
+        const tempData: any = await storageManager?.getTemporaryData();
+        if (tempData?.challengeToken) {
+          challengeTokenRef.current = tempData.challengeToken as string;
         }
       } catch {
         // StorageManager unavailable — continue without persisted token
@@ -322,7 +318,14 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
    */
   const setChallengeToken = async (challengeToken: string | null): Promise<void> => {
     challengeTokenRef.current = challengeToken;
-    await persistChallengeToken(challengeToken);
+    const storageManager: any = await getStorageManager();
+    if (storageManager) {
+      if (challengeToken) {
+        await storageManager.setTemporaryDataParameter('challengeToken', challengeToken);
+      } else {
+        await storageManager.removeTemporaryDataParameter('challengeToken');
+      }
+    }
   };
 
   /**
@@ -562,6 +565,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
               code,
               state,
             },
+            ...(challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : {}),
           } as any;
 
           try {
@@ -633,6 +637,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
                     code,
                     state,
                   },
+                  ...(challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : {}),
                 } as any;
 
                 try {

--- a/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
+++ b/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
@@ -274,7 +274,12 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
   const {theme, colorScheme} = useTheme();
   const {t} = useTranslation();
   const {subtitle: flowSubtitle, title: flowTitle, messages: flowMessages, addMessage, clearMessages} = useFlow();
-  const {meta} = useAsgardeo();
+  const {
+    meta,
+    isInitialized: isSdkInitialized,
+    getChallengeToken,
+    setChallengeToken: persistChallengeToken,
+  } = useAsgardeo();
   const styles: any = useStyles(theme, colorScheme);
 
   const [isLoading, setIsLoading] = useState(false);
@@ -288,9 +293,37 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
     executionId: null,
     isActive: false,
   });
+  const challengeTokenRef: any = useRef<string | null>(null);
 
   const initializationAttemptedRef: any = useRef(false);
   const passkeyProcessedRef: any = useRef(false);
+
+  /**
+   * Restore any challenge token persisted before an OAuth redirect.
+   */
+  useEffect(() => {
+    if (!isSdkInitialized) return;
+
+    (async (): Promise<void> => {
+      try {
+        const token: string | null = await getChallengeToken();
+        if (token) {
+          challengeTokenRef.current = token;
+        }
+      } catch {
+        // StorageManager unavailable — continue without persisted token
+      }
+    })();
+  }, [isSdkInitialized]);
+
+  /**
+   * Updates challengeTokenRef immediately (stale-closure safe) and persists via
+   * the provider's StorageManager so the token survives OAuth redirects.
+   */
+  const setChallengeToken = async (challengeToken: string | null): Promise<void> => {
+    challengeTokenRef.current = challengeToken;
+    await persistChallengeToken(challengeToken);
+  };
 
   /**
    * Handle error responses and extract meaningful error messages
@@ -675,13 +708,15 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
         ...((currentFlow as any).executionId && {executionId: (currentFlow as any).executionId}),
         flowType: (currentFlow as any).flowType || 'REGISTRATION',
         ...(component.id && {action: component.id}),
-        ...((currentFlow as any).challengeToken && {challengeToken: (currentFlow as any).challengeToken}),
+        ...(challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : {}),
         inputs: filteredInputs,
       } as any;
 
       const rawResponse: any = await onSubmit(payload);
       const response: any = normalizeFlowResponseLocal(rawResponse);
       onFlowChange?.(response);
+
+      await setChallengeToken(response.challengeToken ?? null);
 
       if (response.flowStatus === EmbeddedFlowStatus.Complete) {
         onComplete?.(response);
@@ -878,6 +913,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
           const rawResponse: any = await onInitialize();
           const response: any = normalizeFlowResponseLocal(rawResponse);
 
+          await setChallengeToken(response.challengeToken ?? null);
           setCurrentFlow(response);
           setIsFlowInitialized(true);
           onFlowChange?.(response);

--- a/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
+++ b/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
@@ -318,13 +318,17 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
    */
   const setChallengeToken = async (challengeToken: string | null): Promise<void> => {
     challengeTokenRef.current = challengeToken;
-    const storageManager: any = await getStorageManager();
-    if (storageManager) {
-      if (challengeToken) {
-        await storageManager.setTemporaryDataParameter('challengeToken', challengeToken);
-      } else {
-        await storageManager.removeTemporaryDataParameter('challengeToken');
+    try {
+      const storageManager: any = await getStorageManager();
+      if (storageManager) {
+        if (challengeToken) {
+          await storageManager.setTemporaryDataParameter('challengeToken', challengeToken);
+        } else {
+          await storageManager.removeTemporaryDataParameter('challengeToken');
+        }
       }
+    } catch {
+      logger.warn('Failed to persist challenge token in storage.');
     }
   };
 

--- a/packages/react/src/contexts/Asgardeo/AsgardeoContext.ts
+++ b/packages/react/src/contexts/Asgardeo/AsgardeoContext.ts
@@ -64,6 +64,11 @@ export type AsgardeoContextProps = {
    */
   getAccessToken: () => Promise<string>;
   /**
+   * Retrieves the challenge token from temporary storage.
+   * Used by authentication flow components for per-step token rotation.
+   */
+  getChallengeToken: () => Promise<string | null>;
+  /**
    * Function to retrieve the decoded ID token.
    * This function decodes the ID token and returns its payload.
    * It can be used to access user claims and other information contained in the ID token.
@@ -78,6 +83,10 @@ export type AsgardeoContextProps = {
    * @returns A promise that resolves to the ID token.
    */
   getIdToken: () => Promise<string>;
+  /**
+   * Returns the underlying StorageManager instance for reading and writing SDK-managed storage.
+   */
+  getStorageManager: () => Promise<any>;
   /**
    * HTTP request function to make API calls.
    * @param requestConfig - Configuration for the HTTP request.
@@ -151,6 +160,12 @@ export type AsgardeoContextProps = {
   resolveFlowTemplateLiterals: (text: string | undefined) => string;
 
   /**
+   * Persists a challenge token to temporary storage.
+   * Pass `null` to clear the stored token.
+   */
+  setChallengeToken: (token: string | null) => Promise<void>;
+
+  /**
    * Sign-in function to initiate the authentication process.
    * @remark This is the programmatic version of the `SignInButton` component.
    * TODO: Fix the types.
@@ -207,8 +222,10 @@ const AsgardeoContext: Context<AsgardeoContextProps | null> = createContext<null
   },
   exchangeToken: null,
   getAccessToken: null,
+  getChallengeToken: () => Promise.resolve(null),
   getDecodedIdToken: null,
   getIdToken: null,
+  getStorageManager: () => Promise.resolve(null),
   http: {
     request: () => null,
     requestAll: () => null,
@@ -224,6 +241,7 @@ const AsgardeoContext: Context<AsgardeoContextProps | null> = createContext<null
   platform: undefined,
   reInitialize: null,
   resolveFlowTemplateLiterals: (text: string | undefined) => text ?? '',
+  setChallengeToken: () => Promise.resolve(),
   signIn: () => Promise.resolve({} as any),
   signInOptions: {},
   signInSilently: () => Promise.resolve({} as any),

--- a/packages/react/src/contexts/Asgardeo/AsgardeoContext.ts
+++ b/packages/react/src/contexts/Asgardeo/AsgardeoContext.ts
@@ -64,11 +64,6 @@ export type AsgardeoContextProps = {
    */
   getAccessToken: () => Promise<string>;
   /**
-   * Retrieves the challenge token from temporary storage.
-   * Used by authentication flow components for per-step token rotation.
-   */
-  getChallengeToken: () => Promise<string | null>;
-  /**
    * Function to retrieve the decoded ID token.
    * This function decodes the ID token and returns its payload.
    * It can be used to access user claims and other information contained in the ID token.
@@ -160,12 +155,6 @@ export type AsgardeoContextProps = {
   resolveFlowTemplateLiterals: (text: string | undefined) => string;
 
   /**
-   * Persists a challenge token to temporary storage.
-   * Pass `null` to clear the stored token.
-   */
-  setChallengeToken: (token: string | null) => Promise<void>;
-
-  /**
    * Sign-in function to initiate the authentication process.
    * @remark This is the programmatic version of the `SignInButton` component.
    * TODO: Fix the types.
@@ -222,7 +211,6 @@ const AsgardeoContext: Context<AsgardeoContextProps | null> = createContext<null
   },
   exchangeToken: null,
   getAccessToken: null,
-  getChallengeToken: () => Promise.resolve(null),
   getDecodedIdToken: null,
   getIdToken: null,
   getStorageManager: () => Promise.resolve(null),
@@ -241,7 +229,6 @@ const AsgardeoContext: Context<AsgardeoContextProps | null> = createContext<null
   platform: undefined,
   reInitialize: null,
   resolveFlowTemplateLiterals: (text: string | undefined) => text ?? '',
-  setChallengeToken: () => Promise.resolve(),
   signIn: () => Promise.resolve({} as any),
   signInOptions: {},
   signInSilently: () => Promise.resolve({} as any),

--- a/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
+++ b/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
@@ -79,6 +79,7 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
 }: PropsWithChildren<AsgardeoProviderProps>): ReactElement => {
   const reRenderCheckRef: RefObject<boolean> = useRef(false);
   const asgardeo: AsgardeoReactClient = useMemo(() => new AsgardeoReactClient(instanceId), [instanceId]);
+  const storageManagerRef: any = useRef<any>(null);
   const {hasAuthParams, hasCalledForThisInstance} = useBrowserUrl();
   const [user, setUser] = useState<any | null>(null);
   const [currentOrganization, setCurrentOrganization] = useState<Organization | null>(null);
@@ -560,6 +561,39 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
     [asgardeo],
   );
 
+  const getChallengeToken: () => Promise<string | null> = useCallback(async (): Promise<string | null> => {
+    try {
+      const storageManager: any = storageManagerRef.current ?? (await asgardeo.getStorageManager());
+      if (storageManager) {
+        storageManagerRef.current = storageManager;
+        const tempData: any = await storageManager.getTemporaryData();
+        return (tempData?.challengeToken as string) ?? null;
+      }
+    } catch {
+      // StorageManager unavailable
+    }
+    return null;
+  }, [asgardeo]);
+
+  const setChallengeToken: (token: string | null) => Promise<void> = useCallback(
+    async (token: string | null): Promise<void> => {
+      try {
+        const storageManager: any = storageManagerRef.current ?? (await asgardeo.getStorageManager());
+        if (storageManager) {
+          storageManagerRef.current = storageManager;
+          if (token) {
+            await storageManager.setTemporaryDataParameter('challengeToken', token);
+          } else {
+            await storageManager.removeTemporaryDataParameter('challengeToken');
+          }
+        }
+      } catch {
+        // StorageManager unavailable
+      }
+    },
+    [asgardeo],
+  );
+
   const request: (...args: any[]) => Promise<any> = useCallback(
     async (...args: any[]): Promise<any> => asgardeo.request(...args),
     [asgardeo],
@@ -607,8 +641,10 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
       },
       exchangeToken,
       getAccessToken,
+      getChallengeToken,
       getDecodedIdToken,
       getIdToken,
+      getStorageManager: asgardeo.getStorageManager.bind(asgardeo),
       http: {
         request,
         requestAll,
@@ -622,6 +658,7 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
       organizationHandle: config?.organizationHandle,
       platform: config?.platform,
       reInitialize,
+      setChallengeToken,
       signIn,
       signInOptions,
       signInSilently,
@@ -655,6 +692,8 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
       switchOrganization,
       getDecodedIdToken,
       getAccessToken,
+      getChallengeToken,
+      setChallengeToken,
       request,
       requestAll,
       exchangeToken,

--- a/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
+++ b/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
@@ -561,38 +561,13 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
     [asgardeo],
   );
 
-  const getChallengeToken: () => Promise<string | null> = useCallback(async (): Promise<string | null> => {
-    try {
-      const storageManager: any = storageManagerRef.current ?? (await asgardeo.getStorageManager());
-      if (storageManager) {
-        storageManagerRef.current = storageManager;
-        const tempData: any = await storageManager.getTemporaryData();
-        return (tempData?.challengeToken as string) ?? null;
-      }
-    } catch {
-      // StorageManager unavailable
+  const getStorageManager: () => Promise<any> = useCallback(async (): Promise<any> => {
+    const storageManager: any = storageManagerRef.current ?? (await asgardeo.getStorageManager());
+    if (storageManager) {
+      storageManagerRef.current = storageManager;
     }
-    return null;
+    return storageManager;
   }, [asgardeo]);
-
-  const setChallengeToken: (token: string | null) => Promise<void> = useCallback(
-    async (token: string | null): Promise<void> => {
-      try {
-        const storageManager: any = storageManagerRef.current ?? (await asgardeo.getStorageManager());
-        if (storageManager) {
-          storageManagerRef.current = storageManager;
-          if (token) {
-            await storageManager.setTemporaryDataParameter('challengeToken', token);
-          } else {
-            await storageManager.removeTemporaryDataParameter('challengeToken');
-          }
-        }
-      } catch {
-        // StorageManager unavailable
-      }
-    },
-    [asgardeo],
-  );
 
   const request: (...args: any[]) => Promise<any> = useCallback(
     async (...args: any[]): Promise<any> => asgardeo.request(...args),
@@ -641,10 +616,9 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
       },
       exchangeToken,
       getAccessToken,
-      getChallengeToken,
       getDecodedIdToken,
       getIdToken,
-      getStorageManager: asgardeo.getStorageManager.bind(asgardeo),
+      getStorageManager,
       http: {
         request,
         requestAll,
@@ -658,7 +632,6 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
       organizationHandle: config?.organizationHandle,
       platform: config?.platform,
       reInitialize,
-      setChallengeToken,
       signIn,
       signInOptions,
       signInSilently,
@@ -692,8 +665,7 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
       switchOrganization,
       getDecodedIdToken,
       getAccessToken,
-      getChallengeToken,
-      setChallengeToken,
+      getStorageManager,
       request,
       requestAll,
       exchangeToken,


### PR DESCRIPTION
### Purpose
This pull request introduces a per-step challenge token to the authentication, registration and invitation flows in both the JavaScript SDK and React components. The challenge token is issued by the backend and must be included in subsequent requests to safe guard against the replay attacks (CSRF). The implementation ensures that the token is consistently managed in state and session storage, and is passed along with all relevant flow requests.

### Related Issues
- https://github.com/asgardeo/thunder/issues/2008

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-step challenge tokens added to embedded sign-in, sign-up, invite, and accept-invite flows; tokens are returned by responses, can be included in subsequent requests, and are persisted across steps and redirects.
  * React SDK now exposes an async storage manager accessor and integrates token persistence helpers so apps can interact with persisted flow state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->