### PR TITLE
Add challenge token to the passkey registration flow

### DIFF
--- a/.changeset/social-lizards-jog.md
+++ b/.changeset/social-lizards-jog.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/react': patch
+---
+
+Add missing challenge token to the passkey registration

--- a/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
+++ b/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
@@ -797,6 +797,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
         executionId: passkeyState.executionId as string,
         flowType: (currentFlow as any)?.flowType || 'REGISTRATION',
         inputs,
+        ...(challengeTokenRef.current ? {challengeToken: challengeTokenRef.current} : {}),
       } as any;
 
       const nextResponse: any = await onSubmit(payload);


### PR DESCRIPTION
### Purpose
This pull request addresses an issue with passkey registration by ensuring the challenge token is included in the registration payload. This resolves a missing parameter that could prevent successful passkey registration.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the challenge token was not being included during passkey registration and OAuth authentication flows, ensuring proper security token handling across sign-up submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->