### PR TITLE
[WIP] Fix race condition in refresh token issuance

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -149,8 +149,22 @@ jobs:
       - name: 🎭 Install Playwright browsers
         run: pnpm e2e:install
 
+      # - name: 🐳 Start Thunder
+      #   run: pnpm e2e:docker:up:thunder
+
       - name: 🐳 Start Thunder
-        run: pnpm e2e:docker:up:thunder
+        run: |
+          set -euxo pipefail
+          pnpm e2e:docker:up:thunder || {
+            echo "Thunder compose failed. Dumping docker state + logs..."
+            docker ps -a || true
+            docker compose -f e2e/docker-compose.yml ps || true
+            docker compose -f e2e/docker-compose.yml logs --no-color --timestamps || true
+            # If thunder-setup is a container name, also dump it directly:
+            docker logs --timestamps asgardeo-e2e-thunder || true
+            docker inspect asgardeo-e2e-thunder || true
+            exit 1
+          }
 
       - name: 🧪 Run E2E redirect tests against Thunder
         run: pnpm e2e -- --idp thunder --mode redirect

--- a/packages/browser/src/__legacy__/helpers/authentication-helper.ts
+++ b/packages/browser/src/__legacy__/helpers/authentication-helper.ts
@@ -397,9 +397,9 @@ export class AuthenticationHelper<T extends MainThreadClientConfig | WebWorkerCl
           })
           .catch(async (error: HttpError) => {
             if (error?.response?.status === 401 || !error?.response) {
-              let refreshTokenResponse: TokenResponse | User;
+              let refreshTokenResponse: User;
               try {
-                refreshTokenResponse = await this._authenticationClient.refreshAccessToken();
+                refreshTokenResponse = await this.refreshAccessToken();
               } catch (refreshError: any) {
                 if (isHttpHandlerEnabled) {
                   if (typeof httpErrorCallback === 'function') {

--- a/packages/browser/src/__legacy__/helpers/authentication-helper.ts
+++ b/packages/browser/src/__legacy__/helpers/authentication-helper.ts
@@ -65,6 +65,7 @@ export class AuthenticationHelper<T extends MainThreadClientConfig | WebWorkerCl
   protected _spaHelper: SPAHelper<T>;
   protected _instanceId: number;
   protected _isTokenRefreshing: boolean;
+  protected _refreshAccessTokenPromise?: Promise<User>;
 
   public constructor(authClient: AsgardeoAuthClient<T>, spaHelper: SPAHelper<T>) {
     this._authenticationClient = authClient;
@@ -72,6 +73,7 @@ export class AuthenticationHelper<T extends MainThreadClientConfig | WebWorkerCl
     this._spaHelper = spaHelper;
     this._instanceId = this._authenticationClient.getInstanceId();
     this._isTokenRefreshing = false;
+    this._refreshAccessTokenPromise = undefined;
   }
 
   public enableHttpHandler(httpClient: HttpClient): void {
@@ -174,23 +176,33 @@ export class AuthenticationHelper<T extends MainThreadClientConfig | WebWorkerCl
   public async refreshAccessToken(
     enableRetrievingSignOutURLFromSession?: (config: SPACustomGrantConfig) => void,
   ): Promise<User> {
-    try {
-      await this._authenticationClient.refreshAccessToken();
-      const customGrantConfig = await this.getCustomGrantConfigData();
-      if (customGrantConfig) {
-        await this.exchangeToken(customGrantConfig, enableRetrievingSignOutURLFromSession);
-      }
-      this._spaHelper.refreshAccessTokenAutomatically(this);
-
-      return this._authenticationClient.getUser();
-    } catch (error) {
-      const refreshTokenError: Message<string> = {
-        type: REFRESH_ACCESS_TOKEN_ERR0R,
-      };
-
-      window.postMessage(refreshTokenError);
-      return Promise.reject(error);
+    if (this._refreshAccessTokenPromise) {
+      return this._refreshAccessTokenPromise;
     }
+
+    this._refreshAccessTokenPromise = (async (): Promise<User> => {
+      try {
+        await this._authenticationClient.refreshAccessToken();
+        const customGrantConfig = await this.getCustomGrantConfigData();
+        if (customGrantConfig) {
+          await this.exchangeToken(customGrantConfig, enableRetrievingSignOutURLFromSession);
+        }
+        this._spaHelper.refreshAccessTokenAutomatically(this);
+
+        return this._authenticationClient.getUser();
+      } catch (error) {
+        const refreshTokenError: Message<string> = {
+          type: REFRESH_ACCESS_TOKEN_ERR0R,
+        };
+
+        window.postMessage(refreshTokenError);
+        throw error;
+      } finally {
+        this._refreshAccessTokenPromise = undefined;
+      }
+    })();
+
+    return this._refreshAccessTokenPromise;
   }
 
   protected async retryFailedRequests(failedRequest: HttpRequestInterface): Promise<HttpResponse> {


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

This pull request updates the `AuthenticationHelper` class to ensure that only one access token refresh operation can be in progress at a time. It introduces logic to track and reuse an in-flight token refresh promise, preventing duplicate refresh requests and potential race conditions.

Concurrency improvements for access token refresh:

* Added a private property `_refreshAccessTokenPromise` to track an ongoing access token refresh operation, ensuring that concurrent calls to `refreshAccessToken` share the same promise and do not trigger multiple refreshes.
* Updated the `refreshAccessToken` method to check for an existing refresh promise and return it if present, otherwise create and store a new one. The promise is cleared after completion or error, ensuring proper cleanup. [[1]](diffhunk://#diff-c76bf08420924dc5b3798b095e2580ad0d093428d7e66af6e221299a15976e51R179-R183) [[2]](diffhunk://#diff-c76bf08420924dc5b3798b095e2580ad0d093428d7e66af6e221299a15976e51L192-R205)

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed duplicate token refresh requests when multiple requests occur simultaneously.
  * Enhanced error reporting during authentication token refresh failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->