### PR TITLE
Fix TypeScript augmentation file inclusion in the Nuxt npm package

### DIFF
--- a/.changeset/five-games-strive.md
+++ b/.changeset/five-games-strive.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/nuxt': patch
+---
+
+Exclude augments.d.ts from published nuxt npm package

--- a/packages/nuxt/.npmignore
+++ b/packages/nuxt/.npmignore
@@ -1,12 +1,2 @@
 # Ignore TypeScript augmentation files from being processed by consuming apps' build tools
 dist/runtime/types/augments.d.ts
-
-# Development files
-.eslintrc.cjs
-.gitignore
-vitest.config.ts
-prettier.config.cjs
-tsconfig.json
-
-# Source files (only dist is published)
-src/

--- a/packages/nuxt/.npmignore
+++ b/packages/nuxt/.npmignore
@@ -1,0 +1,12 @@
+# Ignore TypeScript augmentation files from being processed by consuming apps' build tools
+dist/runtime/types/augments.d.ts
+
+# Development files
+.eslintrc.cjs
+.gitignore
+vitest.config.ts
+prettier.config.cjs
+tsconfig.json
+
+# Source files (only dist is published)
+src/


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request makes a minor update to the Nuxt package by excluding the `augments.d.ts` TypeScript augmentation file from being published and processed by consuming applications. This helps prevent unnecessary type processing and potential conflicts for users of the package.

- Packaging improvements:
  * Updated `.npmignore` to exclude `dist/runtime/types/augments.d.ts` and other development/source files from the published Nuxt npm package.
  * Added a changeset note documenting the exclusion of `augments.d.ts` from the published package.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated package configuration for the `@asgardeo/nuxt` package, excluding development files and type augmentation files from npm distribution to streamline the published package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->