### PR TITLE
Fix social signup popup callback handling

### DIFF
--- a/.changeset/fix-social-signup-popup-callback.md
+++ b/.changeset/fix-social-signup-popup-callback.md
@@ -1,0 +1,8 @@
+---
+"@asgardeo/react": patch
+"@asgardeo/vue": patch
+---
+
+Fix social signup popup callback handling
+
+When social signup (Google/GitHub) opens a popup for federated authentication, the Callback component now detects the popup context and sends OAuth parameters back to the parent window via postMessage. Also prevents a race condition where both the postMessage handler and the popup URL monitor could double-process the callback.

--- a/packages/react/src/components/auth/Callback/Callback.tsx
+++ b/packages/react/src/components/auth/Callback/Callback.tsx
@@ -85,6 +85,14 @@ export const Callback: FC<CallbackProps> = ({onNavigate, onError}: CallbackProps
         const oauthError: string | null = urlParams.get('error');
         const errorDescription: string | null = urlParams.get('error_description');
 
+        // 1a. If running inside a popup (e.g. social signup), send OAuth params
+        //     back to the opener via postMessage. The parent window's handler will
+        //     close this popup after processing the code.
+        if (window.opener) {
+          window.opener.postMessage({code, state, nonce, error: oauthError, errorDescription}, window.location.origin);
+          return;
+        }
+
         // 2. Validate and retrieve OAuth state from sessionStorage
         if (!state) {
           throw new Error('Missing OAuth state parameter - possible security issue');

--- a/packages/react/src/components/auth/Callback/Callback.tsx
+++ b/packages/react/src/components/auth/Callback/Callback.tsx
@@ -89,7 +89,7 @@ export const Callback: FC<CallbackProps> = ({onNavigate, onError}: CallbackProps
         //     back to the opener via postMessage. The parent window's handler will
         //     close this popup after processing the code.
         if (window.opener) {
-          window.opener.postMessage({code, state, nonce, error: oauthError, errorDescription}, window.location.origin);
+          window.opener.postMessage({code, error: oauthError, errorDescription, nonce, state}, window.location.origin);
           return;
         }
 

--- a/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
+++ b/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
@@ -561,6 +561,8 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
         const {code, state} = event.data;
 
         if (code && state) {
+          hasProcessedCallback = true;
+
           const payload: EmbeddedFlowExecuteRequestPayload = {
             ...((currentFlow as any).executionId && {executionId: (currentFlow as any).executionId}),
             action: '',

--- a/packages/vue/src/components/auth/Callback.ts
+++ b/packages/vue/src/components/auth/Callback.ts
@@ -71,6 +71,14 @@ const Callback: Component = defineComponent({
           return;
         }
 
+        // 1a. If running inside a popup (e.g. social signup), send OAuth params
+        //     back to the opener via postMessage. The parent window's handler will
+        //     close this popup after processing the code.
+        if (window.opener) {
+          window.opener.postMessage({code, state, nonce, error: oauthError, errorDescription}, window.location.origin);
+          return;
+        }
+
         // 2. Validate and retrieve OAuth state from sessionStorage
         if (!state) {
           throw new Error('Missing OAuth state parameter - possible security issue');

--- a/packages/vue/src/components/auth/Callback.ts
+++ b/packages/vue/src/components/auth/Callback.ts
@@ -75,7 +75,7 @@ const Callback: Component = defineComponent({
         //     back to the opener via postMessage. The parent window's handler will
         //     close this popup after processing the code.
         if (window.opener) {
-          window.opener.postMessage({code, state, nonce, error: oauthError, errorDescription}, window.location.origin);
+          window.opener.postMessage({code, error: oauthError, errorDescription, nonce, state}, window.location.origin);
           return;
         }
 


### PR DESCRIPTION
## Summary

- When social signup (Google/GitHub) opens a popup for federated authentication, the `Callback` component now detects the popup context (`window.opener`) and sends OAuth parameters back to the parent window via `postMessage` instead of attempting sessionStorage-based routing (which fails in popup context)
- Prevents a race condition in `BaseSignUp` where both the `postMessage` handler and the popup URL monitor could process the same callback, causing duplicate requests with an invalid challenge token
- Applies the same popup detection fix to the Vue `Callback` component

## Context

The embedded SignUp component uses a popup window for social auth flows. After the user authenticates with Google/GitHub, the IDP redirects the popup to `/callback?code=...&state=...`. Previously, the `Callback` component would throw "Missing OAuth state parameter" or "Invalid OAuth state" because `initiateOAuthRedirect` (which stores state in sessionStorage) is never called for popup-based flows.

## Test plan

- [ ] Test Google social signup via popup flow
- [ ] Test GitHub social signup via popup flow
- [ ] Verify full-page redirect flows (SignIn) still work unchanged
- [ ] Verify Vue Callback handles popup context correctly

Fixes asgardeo/thunder#2368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved OAuth callback handling for popup-based authentication flows
  * Fixed duplicate callback processing during popup authentication
  * Enhanced communication between popup windows and parent application during OAuth sign-up and sign-in flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->