### PR TITLE
Add declarationMap option to TypeScript configuration files

### DIFF
--- a/packages/browser/tsconfig.lib.json
+++ b/packages/browser/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "outDir": "dist",
     "declarationDir": "dist",
     "types": ["node"]

--- a/packages/express/tsconfig.lib.json
+++ b/packages/express/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "outDir": "dist",
     "declarationDir": "dist",
     "types": ["node"]

--- a/packages/i18n/tsconfig.lib.json
+++ b/packages/i18n/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "outDir": "dist",
     "declarationDir": "dist",
     "types": ["node"]

--- a/packages/javascript/tsconfig.lib.json
+++ b/packages/javascript/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "outDir": "dist",
     "declarationDir": "dist",
     "types": ["node"]

--- a/packages/nextjs/tsconfig.lib.json
+++ b/packages/nextjs/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "outDir": "dist",
     "declarationDir": "dist/types",
     "types": ["node"]

--- a/packages/node/tsconfig.lib.json
+++ b/packages/node/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "outDir": "dist",
     "declarationDir": "dist",
     "types": ["node"]

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "outDir": "dist",
     "declarationDir": "dist",
     "types": ["node"]

--- a/packages/vue/tsconfig.lib.json
+++ b/packages/vue/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "outDir": "dist",
     "declarationDir": "dist",
     "types": ["node"]


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request updates the TypeScript configuration for several packages to generate declaration maps alongside type declaration files. Declaration maps help with debugging and improve the developer experience by allowing editors to map `.d.ts` files back to their original TypeScript source.

TypeScript configuration improvements:

* Enabled the `declarationMap` option in the `tsconfig.lib.json` files for the following packages to generate declaration maps:
  * `browser`
  * `express`
  * `i18n`
  * `javascript`
  * `node`
  * `react`
  * `vue`
  * `nextjs`

### Related Issues
- Fixes #490 

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled declaration source maps across all packages for improved TypeScript debugging and enhanced developer experience with type definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->