### PR TITLE
Fix Infinite loop in custom renderers

### DIFF
--- a/.changeset/seven-moles-punch.md
+++ b/.changeset/seven-moles-punch.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/react': patch
+---
+
+Fix Infinite loop in custom renderers

--- a/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
+++ b/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
@@ -18,9 +18,12 @@
 
 import {FlowMetadataResponse, Preferences} from '@asgardeo/browser';
 import {cx} from '@emotion/css';
-import {FC, ReactElement, ReactNode, useCallback, useEffect, useRef, useState} from 'react';
+import {FC, ReactElement, ReactNode, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import useStyles from './BaseAcceptInvite.styles';
 import useAsgardeo from '../../../../../contexts/Asgardeo/useAsgardeo';
+import ComponentRendererContext, {
+  ComponentRendererMap,
+} from '../../../../../contexts/ComponentRenderer/ComponentRendererContext';
 import useTheme from '../../../../../contexts/Theme/useTheme';
 import useTranslation from '../../../../../hooks/useTranslation';
 import {useOAuthCallback} from '../../../../../hooks/v2/useOAuthCallback';
@@ -266,6 +269,7 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
   const {meta, isInitialized, getStorageManager} = useAsgardeo();
   const {t} = useTranslation(preferences?.i18n);
   const {theme} = useTheme();
+  const customRenderers: ComponentRendererMap = useContext(ComponentRendererContext);
   const styles: any = useStyles(theme, theme.vars.colors.text.primary);
   const [isLoading, setIsLoading] = useState(false);
   const [isValidatingToken, setIsValidatingToken] = useState(true);
@@ -778,6 +782,8 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
                 isFormValid,
                 handleInputChange,
                 {
+                  _customRenderers: customRenderers,
+                  _theme: theme,
                   onInputBlur: handleInputBlur,
                   onSubmit: handleSubmit,
                   size,

--- a/packages/react/src/components/presentation/auth/AuthOptionFactory.tsx
+++ b/packages/react/src/components/presentation/auth/AuthOptionFactory.tsx
@@ -16,6 +16,8 @@
  * under the License.
  */
 
+/* eslint-disable no-underscore-dangle */
+
 import {
   FieldType,
   FlowMetadataResponse,
@@ -35,14 +37,13 @@ import {
 } from '@asgardeo/browser';
 import {css} from '@emotion/css';
 import DOMPurify from 'dompurify';
-import {cloneElement, CSSProperties, ReactElement, useContext} from 'react';
+import {cloneElement, CSSProperties, ReactElement} from 'react';
 import {OrganizationUnitPicker} from './OrganizationUnitPicker';
-import ComponentRendererContext, {
+import {
   ComponentRenderer,
   ComponentRenderContext,
   ComponentRendererMap,
 } from '../../../contexts/ComponentRenderer/ComponentRendererContext';
-import useTheme from '../../../contexts/Theme/useTheme';
 import {UseTranslation} from '../../../hooks/useTranslation';
 import Consent from '../../adapters/Consent';
 import {getConsentOptionalKey} from '../../adapters/ConsentCheckboxList';
@@ -190,6 +191,10 @@ const createAuthComponentFromFlow = (
   onInputChange: (name: string, value: string) => void,
   authType: AuthType,
   options: {
+    /** @internal Passed from the host React component so hooks aren't called inside a loop. */
+    _customRenderers?: ComponentRendererMap;
+    /** @internal Passed from the host React component so hooks aren't called inside a loop. */
+    _theme?: any;
     /** Additional data from the flow response, used for different dynamic data */
     additionalData?: Record<string, any>;
     buttonClassName?: string;
@@ -216,8 +221,8 @@ const createAuthComponentFromFlow = (
     variant?: any;
   } = {},
 ): ReactElement | null => {
-  const {theme} = useTheme();
-  const customRenderers: ComponentRendererMap = useContext(ComponentRendererContext);
+  const theme: any = options._theme;
+  const customRenderers: ComponentRendererMap = options._customRenderers ?? {};
 
   const key: string | number = options.key || component.id;
 
@@ -488,7 +493,7 @@ const createAuthComponentFromFlow = (
         const formStyles: CSSProperties = {
           display: 'flex',
           flexDirection: 'column',
-          gap: `calc(${theme.vars.spacing.unit} * 2)`,
+          gap: `calc(${theme?.vars?.spacing?.unit ?? '4px'} * 2)`,
         };
 
         const blockComponents: any = component.components
@@ -659,6 +664,10 @@ export const renderSignInComponents = (
   isFormValid: boolean,
   onInputChange: (name: string, value: string) => void,
   options?: {
+    /** @internal */
+    _customRenderers?: ComponentRendererMap;
+    /** @internal */
+    _theme?: any;
     /** Additional data from the flow response */
     additionalData?: Record<string, any>;
     buttonClassName?: string;
@@ -706,6 +715,10 @@ export const renderSignUpComponents = (
   isFormValid: boolean,
   onInputChange: (name: string, value: string) => void,
   options?: {
+    /** @internal */
+    _customRenderers?: ComponentRendererMap;
+    /** @internal */
+    _theme?: any;
     /** Additional data from the flow response */
     additionalData?: Record<string, any>;
     buttonClassName?: string;
@@ -752,6 +765,10 @@ export const renderInviteUserComponents = (
   isFormValid: boolean,
   onInputChange: (name: string, value: string) => void,
   options?: {
+    /** @internal */
+    _customRenderers?: ComponentRendererMap;
+    /** @internal */
+    _theme?: any;
     /** Additional data from the flow response */
     additionalData?: Record<string, any>;
     buttonClassName?: string;

--- a/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
+++ b/packages/react/src/components/presentation/auth/InviteUser/v2/BaseInviteUser.tsx
@@ -24,9 +24,12 @@ import {
   Preferences,
 } from '@asgardeo/browser';
 import {cx} from '@emotion/css';
-import {FC, ReactElement, ReactNode, useCallback, useEffect, useRef, useState} from 'react';
+import {FC, ReactElement, ReactNode, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import useStyles from './BaseInviteUser.styles';
 import useAsgardeo from '../../../../../contexts/Asgardeo/useAsgardeo';
+import ComponentRendererContext, {
+  ComponentRendererMap,
+} from '../../../../../contexts/ComponentRenderer/ComponentRendererContext';
 import useTheme from '../../../../../contexts/Theme/useTheme';
 import useTranslation from '../../../../../hooks/useTranslation';
 import {normalizeFlowResponse, extractErrorMessage} from '../../../../../utils/v2/flowTransformer';
@@ -258,6 +261,7 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
   const {meta, isInitialized: isSdkInitialized, getStorageManager} = useAsgardeo();
   const {t} = useTranslation(preferences?.i18n);
   const {theme} = useTheme();
+  const customRenderers: ComponentRendererMap = useContext(ComponentRendererContext);
   const styles: any = useStyles(theme, theme.vars.colors.text.primary);
   const [isLoading, setIsLoading] = useState(false);
   const [isFlowInitialized, setIsFlowInitialized] = useState(false);
@@ -605,6 +609,8 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
         isFormValid,
         handleInputChange,
         {
+          _customRenderers: customRenderers,
+          _theme: theme,
           additionalData: currentFlow?.data?.additionalData,
           fetchOrganizationUnitChildren,
           onInputBlur: handleInputBlur,
@@ -614,6 +620,7 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
         },
       ),
     [
+      customRenderers,
       currentFlow?.data?.additionalData,
       fetchOrganizationUnitChildren,
       formValues,
@@ -625,6 +632,7 @@ const BaseInviteUser: FC<BaseInviteUserProps> = ({
       handleInputBlur,
       handleSubmit,
       size,
+      theme,
       variant,
     ],
   );

--- a/packages/react/src/components/presentation/auth/SignIn/v2/BaseSignIn.tsx
+++ b/packages/react/src/components/presentation/auth/SignIn/v2/BaseSignIn.tsx
@@ -24,8 +24,11 @@ import {
   Preferences,
 } from '@asgardeo/browser';
 import {cx} from '@emotion/css';
-import {FC, useState, useCallback, ReactElement, ReactNode} from 'react';
+import {FC, useState, useCallback, useContext, ReactElement, ReactNode} from 'react';
 import useAsgardeo from '../../../../../contexts/Asgardeo/useAsgardeo';
+import ComponentRendererContext, {
+  ComponentRendererMap,
+} from '../../../../../contexts/ComponentRenderer/ComponentRendererContext';
 import FlowProvider from '../../../../../contexts/Flow/FlowProvider';
 import useFlow from '../../../../../contexts/Flow/useFlow';
 import ComponentPreferencesContext from '../../../../../contexts/I18n/ComponentPreferencesContext';
@@ -238,6 +241,7 @@ const BaseSignInContent: FC<BaseSignInProps> = ({
 }: BaseSignInProps): ReactElement => {
   const {meta} = useAsgardeo();
   const {theme} = useTheme();
+  const customRenderers: ComponentRendererMap = useContext(ComponentRendererContext);
   const {t} = useTranslation();
   const {subtitle: flowSubtitle, title: flowTitle, messages: flowMessages, addMessage, clearMessages} = useFlow();
   const styles: any = useStyles(theme, theme.vars.colors.text.primary);
@@ -454,6 +458,8 @@ const BaseSignInContent: FC<BaseSignInProps> = ({
         isFormValid,
         handleInputChange,
         {
+          _customRenderers: customRenderers,
+          _theme: theme,
           additionalData,
           buttonClassName: buttonClasses,
           inputClassName: inputClasses,
@@ -468,12 +474,14 @@ const BaseSignInContent: FC<BaseSignInProps> = ({
       ),
     [
       additionalData,
+      customRenderers,
       formValues,
       touchedFields,
       formErrors,
       isFormValid,
       meta,
       t,
+      theme,
       isLoading,
       size,
       variant,

--- a/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
+++ b/packages/react/src/components/presentation/auth/SignUp/v2/BaseSignUp.tsx
@@ -27,8 +27,11 @@ import {
   Preferences,
 } from '@asgardeo/browser';
 import {cx} from '@emotion/css';
-import {FC, ReactElement, ReactNode, useEffect, useState, useCallback, useRef} from 'react';
+import {FC, ReactElement, ReactNode, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import useAsgardeo from '../../../../../contexts/Asgardeo/useAsgardeo';
+import ComponentRendererContext, {
+  ComponentRendererMap,
+} from '../../../../../contexts/ComponentRenderer/ComponentRendererContext';
 import FlowProvider from '../../../../../contexts/Flow/FlowProvider';
 import useFlow from '../../../../../contexts/Flow/useFlow';
 import ComponentPreferencesContext from '../../../../../contexts/I18n/ComponentPreferencesContext';
@@ -272,6 +275,7 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
   showSubtitle = true,
 }: BaseSignUpProps): ReactElement => {
   const {theme, colorScheme} = useTheme();
+  const customRenderers: ComponentRendererMap = useContext(ComponentRendererContext);
   const {t} = useTranslation();
   const {subtitle: flowSubtitle, title: flowTitle, messages: flowMessages, addMessage, clearMessages} = useFlow();
   const {meta, isInitialized: isSdkInitialized, getStorageManager} = useAsgardeo();
@@ -870,6 +874,8 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
         isFormValid,
         handleInputChange,
         {
+          _customRenderers: customRenderers,
+          _theme: theme,
           buttonClassName: buttonClasses,
           inputClassName: inputClasses,
           onInputBlur: handleInputBlur,
@@ -879,12 +885,14 @@ const BaseSignUpContent: FC<BaseSignUpProps> = ({
         },
       ),
     [
+      customRenderers,
       formValues,
       touchedFields,
       formErrors,
       isFormValid,
       isLoading,
       size,
+      theme,
       variant,
       inputClasses,
       buttonClasses,


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->

Getting a stack exceed error when custom renderers are used:

```bash
Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
    at LoginIdInput (
```

#### Provider

```tsx
<AsgardeoProvider
  baseUrl={import.meta.env.VITE_ASGARDEO_BASE_URL}
  platform="AsgardeoV2"
  applicationId={applicationId}
  preferences={{
    // resolveFromMeta: false,
    theme: {
      mode: 'light',
    },
  }}
  extensions={{
    components: {
      renderers: {
        SBI: sbiRenderer,
      },
    },
  }}
>
  <App />
</AsgardeoProvider>
```
    
### Related Issues
- https://github.com/asgardeo/javascript/issues/470

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
