### PR TITLE
Re-export extensions related types

### DIFF
--- a/.changeset/big-ducks-repeat.md
+++ b/.changeset/big-ducks-repeat.md
@@ -1,0 +1,6 @@
+---
+'@asgardeo/react': patch
+'@asgardeo/vue': patch
+---
+
+Re-export extensions related types

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -326,4 +326,7 @@ export {
   type EmbeddedSignUpFlowInitiateRequestV2 as EmbeddedSignUpFlowInitiateRequest,
   type EmbeddedSignUpFlowRequestV2 as EmbeddedSignUpFlowRequest,
   type EmbeddedSignUpFlowErrorResponseV2 as EmbeddedSignUpFlowErrorResponse,
+  type ComponentRenderContext,
+  type ComponentsExtensions,
+  type ComponentRenderer,
 } from '@asgardeo/browser';

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -247,4 +247,7 @@ export {
   type EmbeddedSignUpFlowInitiateRequestV2 as EmbeddedSignUpFlowInitiateRequest,
   type EmbeddedSignUpFlowRequestV2 as EmbeddedSignUpFlowRequest,
   type EmbeddedSignUpFlowErrorResponseV2 as EmbeddedSignUpFlowErrorResponse,
+  type ComponentRenderContext,
+  type ComponentsExtensions,
+  type ComponentRenderer,
 } from '@asgardeo/browser';


### PR DESCRIPTION
### Purpose
<!-- Describe the problem, feature, improvement or the change introduces by the PR briefly. Add screenshots/GIFs if UI/UX changes are introduced. -->
This pull request updates both the React and Vue SDK packages to re-export several types related to component extensions from the `@asgardeo/browser` package. This makes these types directly available to consumers of the React and Vue SDKs, improving type accessibility and developer experience.

**Type re-exports for extensions:**

* [`packages/react/src/index.ts`](diffhunk://#diff-1cee8646d2cfba37d6ce6a6e9a8d16f8caba0b99fc3a1ad0cb997ed8c7384d2eR329-R331): Re-exported the `ComponentRenderContext`, `ComponentsExtensions`, and `ComponentRenderer` types from `@asgardeo/browser`.
* [`packages/vue/src/index.ts`](diffhunk://#diff-53baa390cbb0872ba29c9041efb851643b5f31c9e3e050ee7c4244b3905e4273R250-R252): Re-exported the `ComponentRenderContext`, `ComponentsExtensions`, and `ComponentRenderer` types from `@asgardeo/browser`.

**Documentation:**

* [`.changeset/big-ducks-repeat.md`](diffhunk://#diff-4fc3f0109365b37a1b5fd59672f5a15ed314a521099a90aa81d59b676741dee3R1-R6): Added a changeset entry describing the patch and the re-export of extension-related types.

### Related Issues
- https://github.com/asgardeo/javascript/issues/470

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ComponentRenderContext, ComponentsExtensions, and ComponentRenderer type exports to React and Vue packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->