### PR TITLE
Fix OAuth redirection handling in invite flow

### DIFF
--- a/.changeset/three-flowers-sneeze.md
+++ b/.changeset/three-flowers-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/react': patch
+---
+
+Fix OAuth redirection handling in invite flow

--- a/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
+++ b/packages/react/src/components/presentation/auth/AcceptInvite/v2/BaseAcceptInvite.tsx
@@ -634,6 +634,15 @@ const BaseAcceptInvite: FC<BaseAcceptInviteProps> = ({
 
         await setChallengeToken(response.challengeToken ?? null);
 
+        if (response.type === 'REDIRECTION') {
+          const redirectURL: any = response.data?.redirectURL || (response as any)?.redirectURL;
+
+          if (redirectURL && typeof window !== 'undefined') {
+            initiateOAuthRedirect(redirectURL);
+            return;
+          }
+        }
+
         // Check for error (invalid token)
         if (response.flowStatus === 'ERROR') {
           setIsTokenInvalid(true);


### PR DESCRIPTION
### Purpose
This pull request introduces a conditional OAuth redirection flow in the `BaseAcceptInvite` component. Now, if the server response indicates a redirection type, the component will automatically initiate an OAuth redirect using the provided URL.

### Related Issues
- https://github.com/thunder-id/thunderid/issues/2712

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the invite acceptance process to streamline OAuth redirects, providing faster authentication when required during invite validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/asgardeo/javascript/pull/516)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->