### PR TITLE
Add token refresh logic if the user's access token is expired

### DIFF
--- a/.changeset/hot-wombats-lick.md
+++ b/.changeset/hot-wombats-lick.md
@@ -1,0 +1,5 @@
+---
+'@asgardeo/browser': patch
+---
+
+Add token refresh logic if the user's access token is expired

--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         node-version: [lts/*]
-        pnpm-version: [v10]
+        pnpm-version: [latest]
     steps:
       - name: ⬇️ Checkout
         id: checkout

--- a/packages/browser/src/__legacy__/helpers/authentication-helper.ts
+++ b/packages/browser/src/__legacy__/helpers/authentication-helper.ts
@@ -706,6 +706,28 @@ export class AuthenticationHelper<T extends MainThreadClientConfig | WebWorkerCl
   }
 
   public async isSignedIn(): Promise<boolean> {
-    return this._authenticationClient.isSignedIn();
+    if (await this._authenticationClient.isSignedIn()) {
+      return true;
+    }
+
+    // A refresh is already in progress — wait for it to finish then re-check.
+    if (this._isTokenRefreshing) {
+      await SPAUtils.until(() => !this._isTokenRefreshing);
+
+      return this._authenticationClient.isSignedIn();
+    }
+
+    // Token may be expired — attempt a silent refresh before giving up.
+    try {
+      this._isTokenRefreshing = true;
+      await this.refreshAccessToken();
+      this._isTokenRefreshing = false;
+
+      return true;
+    } catch {
+      this._isTokenRefreshing = false;
+
+      return false;
+    }
   }
 }


### PR DESCRIPTION
### Purpose

Previously, `isSignedIn` in `AuthenticationHelper` returned false immediately when the access token was expired, causing the `SPA-AUTH_CLIENT-VM-IV02` error to be thrown for any method that required authentication (e.g., after a long idle period where the SPAHelper timer was no longer active).

This fix attempts a silent token refresh via the browser's `refreshAccessToken` before returning `false`. If the refresh succeeds, `isSignedIn` returns `true` and the SPAHelper timer is re-armed. If the refresh fails, it returns `false` as before.

The fix is intentionally scoped to the browser layer (AuthenticationHelper) so it uses the browser-specific refresh flow without introducing network side effects into the base `@asgardeo/javascript` client's `isSignedIn`, which is a shared pure-check method.

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable signed-in detection: waits for ongoing token refreshes and triggers automatic refreshes so signed-in status reflects current authentication state.

* **Refactor**
  * Internal authentication flow and messaging cleaned up for clearer, more robust behavior.

* **Chores**
  * CI workflow updated to use the latest package manager version for linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->