### PR TITLE
test(vue): add unit tests for getDisplayName utility

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,5 @@
   },
   "publishConfig": {
     "access": "restricted"
-  },
-  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -52,5 +52,6 @@
   },
   "publishConfig": {
     "access": "restricted"
-  }
+  },
+  "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
 }

--- a/packages/vue/src/__tests__/utils/getDisplayName.test.ts
+++ b/packages/vue/src/__tests__/utils/getDisplayName.test.ts
@@ -52,6 +52,15 @@ describe('getDisplayName', () => {
     const result = getDisplayName(mergedMappings, user, ['firstName']);
     expect(result).toBe('John');
   });
+  it('returns name when firstName, lastName, username, and email are missing', () => {
+    mockGet.mockReturnValueOnce(undefined); // firstName
+    mockGet.mockReturnValueOnce(undefined); // lastName
+    mockGet.mockReturnValueOnce(undefined); // username
+    mockGet.mockReturnValueOnce(undefined); // email
+    mockGet.mockReturnValueOnce('Jane Fullname'); // name
+    const result = getDisplayName(mergedMappings, user);
+    expect(result).toBe('Jane Fullname');
+  });
 
   it('skips empty displayAttributes and uses firstName and lastName', () => {
     mockGet.mockReturnValueOnce('Jane');

--- a/packages/vue/src/__tests__/utils/getDisplayName.test.ts
+++ b/packages/vue/src/__tests__/utils/getDisplayName.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import getDisplayName from '../../utils/getDisplayName';
+
+vi.mock('../../utils/getMappedUserProfileValue', () => ({
+  default: vi.fn(),
+}));
+
+import getMappedUserProfileValue from '../../utils/getMappedUserProfileValue';
+
+const mockGet = getMappedUserProfileValue as ReturnType<typeof vi.fn>;
+
+describe('getDisplayName', () => {
+  const mergedMappings = {};
+  const user = {} as any;
+
+  beforeEach(() => {
+    mockGet.mockReset();
+  });
+
+  it('returns User when nothing is found', () => {
+    mockGet.mockReturnValue(undefined);
+    const result = getDisplayName(mergedMappings, user);
+    expect(result).toBe('User');
+  });
+
+  it('returns firstName and lastName combined', () => {
+    mockGet.mockReturnValueOnce('Jane');
+    mockGet.mockReturnValueOnce('Doe');
+    const result = getDisplayName(mergedMappings, user);
+    expect(result).toBe('Jane Doe');
+  });
+
+  it('returns username when no firstName or lastName', () => {
+    mockGet.mockReturnValueOnce(undefined);
+    mockGet.mockReturnValueOnce(undefined);
+    mockGet.mockReturnValueOnce('janedoe');
+    const result = getDisplayName(mergedMappings, user);
+    expect(result).toBe('janedoe');
+  });
+
+  it('returns email when no firstName lastName or username', () => {
+    mockGet.mockReturnValueOnce(undefined);
+    mockGet.mockReturnValueOnce(undefined);
+    mockGet.mockReturnValueOnce(undefined);
+    mockGet.mockReturnValueOnce('jane@example.com');
+    const result = getDisplayName(mergedMappings, user);
+    expect(result).toBe('jane@example.com');
+  });
+
+  it('returns value from displayAttributes when found', () => {
+    mockGet.mockReturnValueOnce('John');
+    const result = getDisplayName(mergedMappings, user, ['firstName']);
+    expect(result).toBe('John');
+  });
+
+  it('skips empty displayAttributes and uses firstName and lastName', () => {
+    mockGet.mockReturnValueOnce('Jane');
+    mockGet.mockReturnValueOnce('Doe');
+    const result = getDisplayName(mergedMappings, user, []);
+    expect(result).toBe('Jane Doe');
+  });
+});

--- a/packages/vue/src/__tests__/utils/getDisplayName.test.ts
+++ b/packages/vue/src/__tests__/utils/getDisplayName.test.ts
@@ -68,4 +68,14 @@ describe('getDisplayName', () => {
     const result = getDisplayName(mergedMappings, user, []);
     expect(result).toBe('Jane Doe');
   });
+
+  it('returns name when firstName, lastName, username, and email are missing', () => {
+    mockGet.mockReturnValueOnce(undefined); // firstName
+    mockGet.mockReturnValueOnce(undefined); // lastName
+    mockGet.mockReturnValueOnce(undefined); // username
+    mockGet.mockReturnValueOnce(undefined); // email
+    mockGet.mockReturnValueOnce('Jane Fullname'); // name
+    const result = getDisplayName(mergedMappings, user);
+    expect(result).toBe('Jane Fullname');
+  });
 });


### PR DESCRIPTION
### Purpose
I noticed that the `getDisplayName` utility function in the `@asgardeo/vue` package had no unit tests at all. This PR adds 6 tests covering all the main code paths — including fallback behavior when user attributes are missing, and when displayAttributes are provided.

### Related Issues
- Closes #170

### Related PRs
- N/A

### Checklist
- [x] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [x] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [x] Unit tests provided.

### Security checks
- [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added/expanded coverage for display name resolution, including default naming, first/last name combinations, username/email fallbacks, configurable display attributes, and correct handling when attribute configurations are empty.
* **Chores**
  * Pinned the project’s package manager version in the package manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->