### PR TITLE
Fix infinite loop of refresh grant requests when the refresh token is expired or revoked

### DIFF
--- a/.changeset/fix-refresh-token-loop.md
+++ b/.changeset/fix-refresh-token-loop.md
@@ -1,0 +1,6 @@
+---
+'@asgardeo/browser': patch
+'@asgardeo/react': patch
+---
+
+Fix infinite loop of refresh grant requests when the refresh token is expired or revoked

--- a/packages/browser/src/__legacy__/helpers/authentication-helper.ts
+++ b/packages/browser/src/__legacy__/helpers/authentication-helper.ts
@@ -65,6 +65,7 @@ export class AuthenticationHelper<T extends MainThreadClientConfig | WebWorkerCl
   protected _spaHelper: SPAHelper<T>;
   protected _instanceId: number;
   protected _isTokenRefreshing: boolean;
+  protected _hasRefreshFailed: boolean;
 
   public constructor(authClient: AsgardeoAuthClient<T>, spaHelper: SPAHelper<T>) {
     this._authenticationClient = authClient;
@@ -72,6 +73,11 @@ export class AuthenticationHelper<T extends MainThreadClientConfig | WebWorkerCl
     this._spaHelper = spaHelper;
     this._instanceId = this._authenticationClient.getInstanceId();
     this._isTokenRefreshing = false;
+    this._hasRefreshFailed = false;
+  }
+
+  public hasRefreshFailed(): boolean {
+    return this._hasRefreshFailed;
   }
 
   public enableHttpHandler(httpClient: HttpClient): void {
@@ -180,6 +186,7 @@ export class AuthenticationHelper<T extends MainThreadClientConfig | WebWorkerCl
       if (customGrantConfig) {
         await this.exchangeToken(customGrantConfig, enableRetrievingSignOutURLFromSession);
       }
+      this._hasRefreshFailed = false;
       this._spaHelper.refreshAccessTokenAutomatically(this);
 
       return this._authenticationClient.getUser();
@@ -481,6 +488,7 @@ export class AuthenticationHelper<T extends MainThreadClientConfig | WebWorkerCl
       return this._authenticationClient
         .requestAccessToken(authorizationCode, sessionState ?? '', state ?? '', undefined, tokenRequestConfig)
         .then(async () => {
+          this._hasRefreshFailed = false;
           // Disable this temporarily
           /* if (config.storage === Storage.BrowserMemory) {
                         SPAUtils.setSignOutURL(await _authenticationClient.getSignOutUrl());
@@ -717,6 +725,13 @@ export class AuthenticationHelper<T extends MainThreadClientConfig | WebWorkerCl
       return this._authenticationClient.isSignedIn();
     }
 
+    // Skip the refresh attempt if a previous one already failed with this session's
+    // tokens — avoids an infinite loop of refresh grant requests when the refresh
+    // token is expired or revoked (flag is cleared on fresh sign-in or successful refresh).
+    if (this._hasRefreshFailed) {
+      return false;
+    }
+
     // Token may be expired — attempt a silent refresh before giving up.
     try {
       this._isTokenRefreshing = true;
@@ -726,6 +741,7 @@ export class AuthenticationHelper<T extends MainThreadClientConfig | WebWorkerCl
       return true;
     } catch {
       this._isTokenRefreshing = false;
+      this._hasRefreshFailed = true;
 
       return false;
     }

--- a/packages/browser/src/__legacy__/helpers/spa-helper.ts
+++ b/packages/browser/src/__legacy__/helpers/spa-helper.ts
@@ -54,6 +54,7 @@ export class SPAHelper<T extends MainThreadClientConfig | WebWorkerClientConfig>
 
       if (timeUntilRefresh <= 0) {
         if (this._isTokenRefreshLoading) return;
+        if (authenticationHelper.hasRefreshFailed()) return;
 
         this._isTokenRefreshLoading = true;
         try {

--- a/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
+++ b/packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx
@@ -388,6 +388,23 @@ const AsgardeoProvider: FC<PropsWithChildren<AsgardeoProviderProps>> = ({
     };
   }, [asgardeo]);
 
+  // When the refresh token is expired or revoked, the browser SDK posts a
+  // 'refresh-access-token-error' message. Sync the React context so components
+  // stop calling auth methods and the user is redirected to sign in again.
+  useEffect(() => {
+    const handleRefreshTokenError = (event: MessageEvent): void => {
+      if (event?.data?.type === 'refresh-access-token-error') {
+        setIsSignedInSync(false);
+      }
+    };
+
+    window.addEventListener('message', handleRefreshTokenError);
+
+    return (): void => {
+      window.removeEventListener('message', handleRefreshTokenError);
+    };
+  }, []);
+
   useEffect(() => {
     (async (): Promise<void> => {
       try {


### PR DESCRIPTION
### Purpose
$subject

### Problem

**Root cause:** 

`isSignedIn()` now attempts a refresh grant whenever the access token is expired. The existing `_isTokenRefreshing` flag only guards against *concurrent* refresh attempts — it resets to `false` after each failure. This meant every subsequent call to `isSignedIn()` (from `_validateMethod`, navigation guards, `AsgardeoProvider`'s polling interval, etc.) would fire another `/token` request, creating a rapid-fire loop with no exit condition.

There were two additional contributing factors:
1. `AsgardeoProvider`'s React context (`isSignedInSync`) was never updated when the refresh failed, so app hooks continued to call auth methods believing the user was still signed in.
2. `scheduleAutoRefresh()` in `AsgardeoProvider` was calling `refreshAccessTokenAutomatically()` which bypasses `isSignedIn()` entirely and calls `refreshAccessToken()` directly — so the loop also fired through the periodic refresh path.

---

### Changes

**`packages/browser/src/__legacy__/helpers/authentication-helper.ts`**

- Added `_hasRefreshFailed: boolean` flag (initialized `false`) to track whether a refresh attempt has already failed for the current session's tokens.
- After the first refresh failure in `isSignedIn()`, sets `_hasRefreshFailed = true` — all subsequent `isSignedIn()` calls return `false` immediately without hitting the network.
- Resets `_hasRefreshFailed = false` in two places:
  - `refreshAccessToken()` on success — covers the HTTP interceptor and SPAHelper timer paths.
  - `requestAccessToken()` callback — covers fresh sign-in via auth code exchange.
- Added `hasRefreshFailed()` public getter so `SPAHelper` can read the flag.

**`packages/browser/src/__legacy__/helpers/spa-helper.ts`**

- Added `authenticationHelper.hasRefreshFailed()` check in the `timeUntilRefresh <= 0` immediate-refresh path inside `refreshAccessTokenAutomatically()`. Prevents the SPAHelper from firing a redundant refresh attempt after `isSignedIn()` has already marked the refresh token as failed.

**`packages/react/src/contexts/Asgardeo/AsgardeoProvider.tsx`**

- Added a `useEffect` listener for the `refresh-access-token-error` window message (posted by `refreshAccessToken()` on failure). When received, sets `isSignedInSync = false` so the React context correctly reflects the unauthenticated state — stopping app components and hooks from continuing to call auth methods.

---

### Behavior after fix

| Scenario | Before | After |
|---|---|---|
| Refresh token expired, `isSignedIn()` called repeatedly | Refresh grant fired on every call | Refresh grant fired once; all subsequent calls return `false` immediately |
| `scheduleAutoRefresh()` called after a failed refresh | Fires another refresh grant | Blocked by `hasRefreshFailed()` check in SPAHelper |
| React hooks after refresh failure | Keep calling `getIdToken()` (context still shows signed in) | `isSignedInSync = false` propagated via window message; hooks stop |
| Fresh sign-in after token expiry | `_hasRefreshFailed` never reset | Reset on `requestAccessToken` success; normal refresh behavior resumes |


### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [ ] Followed the [CONTRIBUTING](https://github.com/asgardeo/javascript/blob/main/CONTRIBUTING.md) guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
- [ ] Unit tests provided. (Add links if there are any)

### Security checks
- [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines?
- [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an infinite loop of refresh token requests that occurred when the refresh token was expired or revoked. The authentication system now properly handles failed refresh attempts and updates the signed-in state accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->